### PR TITLE
Loire: fix init.recovery.rc

### DIFF
--- a/rootdir/init.recovery.loire.rc
+++ b/rootdir/init.recovery.loire.rc
@@ -1,5 +1,5 @@
 on fs
-    symlink /dev/block/platform/soc.0/f9824900.sdhci /dev/block/bootdevice
+    symlink /dev/block/platform/soc.0/7824900.sdhci /dev/block/bootdevice
 
 on boot
     write /sys/class/android_usb/android0/idVendor 0FCE


### PR DESCRIPTION
Following: https://github.com/sonyxperiadev/device-sony-loire/blob/master/rootdir/init.loire.rc#L20

Signed-off-by: David Viteri <davidteri91@gmail.com>