### PR TITLE
loire: add missing key

### DIFF
--- a/rootdir/system/usr/keylayout/gpio-keys.kl
+++ b/rootdir/system/usr/keylayout/gpio-keys.kl
@@ -27,5 +27,6 @@
 
 key 115   VOLUME_UP
 key 114   VOLUME_DOWN
+key 102   HOME
 key 528   FOCUS
 key 766   CAMERA


### PR DESCRIPTION
picked from 34.0.A.1.277

Signed-off-by: David Viteri <davidteri91@gmail.com>