### PR TITLE
cpuquiet: tune hotplugging for loire platform

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -5,11 +5,11 @@
 cpuquiet.low.min_cpus=1
 cpuquiet.low.max_cpus=4
 rqbalance.low.balance_level=80
-rqbalance.low.up_threshold=200 450 550 580 600 640 750 4294967295
-rqbalance.low.down_threshold=0 120 320 400 440 500 550 700
+rqbalance.low.up_threshold=100 200 300 800 900 4294967295
+rqbalance.low.down_threshold=0 75 175 275 775 875
 
 cpuquiet.normal.min_cpus=4
 cpuquiet.normal.max_cpus=6
 rqbalance.normal.balance_level=40
-rqbalance.normal.up_threshold=100 300 400 500 525 600 700 4294967295
-rqbalance.normal.down_threshold=0 100 300 400 425 500 600 650
+rqbalance.normal.up_threshold=50 100 150 400 450 4294967295
+rqbalance.normal.down_threshold=0 25 75 125 375 425


### PR DESCRIPTION
Adjust for hexcore SoC
make little cores easy to online
make big cores difficult to online

Signed-off-by: Adam Farden <adam@farden.cz>

![screenshot_20160703-131846](https://cloud.githubusercontent.com/assets/1012095/16545149/87a7d876-4121-11e6-901e-715015b72e1d.png)
