### PR TITLE
loire: fix dmesg spam

### DIFF
--- a/rootdir/init.loire.rc
+++ b/rootdir/init.loire.rc
@@ -57,7 +57,7 @@ on boot
     write /dev/cpuset/system-background/cpus 0-3
 
 # OSS WLAN and BT MAC setup
-service macaddrsetup /system/bin/macaddrsetup
+service macaddrsetup /system/bin/macaddrsetup /sys/devices/platform/bcmdhd_wlan/macaddr
     user root
     disabled
     oneshot


### PR DESCRIPTION
[    8.366864] somc_wifi_get_mac_addr: Failed to get information from file /sys/devices/platform/bcmdhd_wlan/macaddr (-2)

Signed-off-by: David Viteri <davidteri91@gmail.com>