### PR TITLE
loire: remove unused codecs in AOSP

### DIFF
--- a/rootdir/system/etc/media_codecs.xml
+++ b/rootdir/system/etc/media_codecs.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<!-- Copyright (C) 2012 The Android Open Source Project
-     Copyright (C) 2014 The Linux Foundation. All rights reserved.
-     Not a contribution.
+<!-- Copyright 2015 The Android Open Source Project
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -14,6 +12,7 @@
      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
      See the License for the specific language governing permissions and
      limitations under the License.
+
 -->
 
 <!--
@@ -77,38 +76,6 @@ Only the three quirks included above are recognized at this point:
     matching surfaceflinger support that can render the custom format to
     a texture and possibly other code, so just DON'T USE THIS QUIRK.
 
-
--->
-
-<!--
-  Decoder capabilities for 8956
-   __________ _________________________________________ ___________________
-  | Codec    | W       H       fps     Mbps    MB/s    | Encode Secure-dec |
-  |__________|_________________________________________|___________________|
-  | hevc     | 3840    2160    30      100     972000  |  Y       Y        |
-  | h264     | 3840    2160    30      100     972000  |  Y       Y        |
-  | h263     |  864     480    30        2      48600  |  Y       N        |
-  | mpeg4    | 1920    1088    60       60     489600  |  Y       N        |
-  | mpeg2    | 1920    1088    30       40     244800  |  N       Y        |
-  | vc1      | 1920    1088    60       60     489600  |  N       N        |
-  | vp8      | 3840    2160    30      100     972000  |  Y       N        |
-  | divx3    |  720     480    30        2      40500  |  N       N        |
-  | div4/5/6 | 1920    1088    30       10     244800  |  N       N        |
-  |__________|_________________________________________|___________________|
-
--->
-
-<!--
-  Encoder capabilities for 8956
-   ____________________________________________________
-  | Codec    | W       H       fps     Mbps    MB/s    |
-  |__________|_________________________________________|
-  | hevc     | 3840    2160    30      100     972000  |
-  | h264     | 3840    2160    30      100     972000  |
-  | h263     |  864     480    30        2      48600  |
-  | mpeg4    | 1920    1088    30       40     244800  |
-  | vp8      | 1920    1088    30       40     244800  |
-  |____________________________________________________|
 -->
 
 <MediaCodecs>
@@ -118,39 +85,6 @@ Only the three quirks included above are recognized at this point:
         <Setting name="max-video-encoder-input-buffers" value="11" />
     </Settings>
     <Encoders>
-        <!-- Audio Hardware  -->
-        <MediaCodec name="OMX.qcom.audio.encoder.evrc" type="audio/evrc" >
-            <Quirk name="requires-allocate-on-input-ports" />
-            <Quirk name="requires-allocate-on-output-ports" />
-        </MediaCodec>
-        <MediaCodec name="OMX.qcom.audio.encoder.qcelp13" type="audio/qcelp" >
-            <Quirk name="requires-allocate-on-input-ports" />
-            <Quirk name="requires-allocate-on-output-ports" />
-        </MediaCodec>
-        <!-- Audio Software  -->
-        <!-- Video Hardware  -->
-        <MediaCodec name="OMX.qcom.video.encoder.hevc" type="video/hevc" >
-            <Quirk name="requires-allocate-on-input-ports" />
-            <Quirk name="requires-allocate-on-output-ports" />
-            <Quirk name="requires-loaded-to-idle-after-allocation" />
-            <Limit name="size" min="176x64" max="3840x2160" />
-            <Limit name="alignment" value="2x2" />
-            <Limit name="block-size" value="16x16" />
-            <Limit name="blocks-per-second" min="1" max="972000" />
-            <Limit name="bitrate" range="1-100000000" />
-            <Limit name="concurrent-instances" max="16" />
-        </MediaCodec>
-        <MediaCodec name="OMX.qcom.video.encoder.avc" type="video/avc" >
-            <Quirk name="requires-allocate-on-input-ports" />
-            <Quirk name="requires-allocate-on-output-ports" />
-            <Quirk name="requires-loaded-to-idle-after-allocation" />
-            <Limit name="size" min="96x64" max="3840x2160" />
-            <Limit name="alignment" value="2x2" />
-            <Limit name="block-size" value="16x16" />
-            <Limit name="blocks-per-second" min="1" max="972000" />
-            <Limit name="bitrate" range="1-100000000" />
-            <Limit name="concurrent-instances" max="16" />
-        </MediaCodec>
         <MediaCodec name="OMX.qcom.video.encoder.mpeg4" type="video/mp4v-es" >
             <Quirk name="requires-allocate-on-input-ports" />
             <Quirk name="requires-allocate-on-output-ports" />
@@ -173,6 +107,17 @@ Only the three quirks included above are recognized at this point:
             <Limit name="bitrate" range="1-2000000" />
             <Limit name="concurrent-instances" max="16" />
         </MediaCodec>
+        <MediaCodec name="OMX.qcom.video.encoder.avc" type="video/avc" >
+            <Quirk name="requires-allocate-on-input-ports" />
+            <Quirk name="requires-allocate-on-output-ports" />
+            <Quirk name="requires-loaded-to-idle-after-allocation" />
+            <Limit name="size" min="96x64" max="3840x2160" />
+            <Limit name="alignment" value="2x2" />
+            <Limit name="block-size" value="16x16" />
+            <Limit name="blocks-per-second" min="1" max="972000" />
+            <Limit name="bitrate" range="1-100000000" />
+            <Limit name="concurrent-instances" max="16" />
+        </MediaCodec>
         <MediaCodec name="OMX.qcom.video.encoder.vp8" type="video/x-vnd.on2.vp8" >
             <Quirk name="requires-allocate-on-input-ports" />
             <Quirk name="requires-allocate-on-output-ports" />
@@ -186,9 +131,6 @@ Only the three quirks included above are recognized at this point:
         </MediaCodec>
     </Encoders>
     <Decoders>
-        <!-- Audio Hardware  -->
-        <!-- Audio Software  -->
-        <!-- Video Hardware  -->
         <MediaCodec name="OMX.qcom.video.decoder.avc" type="video/avc" >
             <Quirk name="requires-allocate-on-input-ports" />
             <Quirk name="requires-allocate-on-output-ports" />
@@ -231,39 +173,6 @@ Only the three quirks included above are recognized at this point:
             <Limit name="block-size" value="16x16" />
             <Limit name="blocks-per-second" min="1" max="48600" />
             <Limit name="bitrate" range="1-2000000" />
-            <Feature name="adaptive-playback" />
-            <Limit name="concurrent-instances" max="16" />
-        </MediaCodec>
-        <MediaCodec name="OMX.qcom.video.decoder.divx" type="video/divx" >
-            <Quirk name="requires-allocate-on-input-ports" />
-            <Quirk name="requires-allocate-on-output-ports" />
-            <Limit name="size" min="64x64" max="1920x1088" />
-            <Limit name="alignment" value="2x2" />
-            <Limit name="block-size" value="16x16" />
-            <Limit name="blocks-per-second" min="1" max="244800" />
-            <Limit name="bitrate" range="1-10000000" />
-            <Feature name="adaptive-playback" />
-            <Limit name="concurrent-instances" max="16" />
-        </MediaCodec>
-        <MediaCodec name="OMX.qcom.video.decoder.divx311" type="video/divx311" >
-            <Quirk name="requires-allocate-on-input-ports" />
-            <Quirk name="requires-allocate-on-output-ports" />
-            <Limit name="size" min="64x64" max="720x480" />
-            <Limit name="alignment" value="2x2" />
-            <Limit name="block-size" value="16x16" />
-            <Limit name="blocks-per-second" min="1" max="40500" />
-            <Limit name="bitrate" range="1-2000000" />
-            <Feature name="adaptive-playback" />
-            <Limit name="concurrent-instances" max="16" />
-        </MediaCodec>
-        <MediaCodec name="OMX.qcom.video.decoder.divx4" type="video/divx4" >
-            <Quirk name="requires-allocate-on-input-ports" />
-            <Quirk name="requires-allocate-on-output-ports" />
-            <Limit name="size" min="64x64" max="1920x1088" />
-            <Limit name="alignment" value="2x2" />
-            <Limit name="block-size" value="16x16" />
-            <Limit name="blocks-per-second" min="1" max="244800" />
-            <Limit name="bitrate" range="1-10000000" />
             <Feature name="adaptive-playback" />
             <Limit name="concurrent-instances" max="16" />
         </MediaCodec>


### PR DESCRIPTION
let this as base for M and N following Nexus Devices

Signed-off-by: David Viteri <davidteri91@gmail.com>