### PR TITLE
Revert "sony: loire: Set BT default name dynamically"

### DIFF
--- a/bluetooth/bdroid_buildcfg.h
+++ b/bluetooth/bdroid_buildcfg.h
@@ -17,22 +17,6 @@
 #ifndef _BDROID_BUILDCFG_H
 #define _BDROID_BUILDCFG_H
 
-#include <cutils/properties.h>
-#include <string.h>
-
-inline const char* getBTDefaultName()
-{
-    char device[PROPERTY_VALUE_MAX];
-    property_get("ro.boot.hardware", device, "");
-
-    if (!strcmp("suzu", device)) {
-        return "Xperia X";
-    }
-
-    return "Xperia";
-}
-
-#define BTM_DEF_LOCAL_NAME getBTDefaultName()
 #define BTM_WBS_INCLUDED TRUE
 #define BTIF_HF_WBS_PREFERRED TRUE
 #define BLE_VND_INCLUDED TRUE


### PR DESCRIPTION
clang breaks this feature so revert it until the proper fix.

This reverts commit 2c257bf26868290c6880ba5cf2d03964f78921d5.