### PR TITLE
[master] sony: loire: Reintroduce BT device name

### DIFF
--- a/bluetooth/bdroid_buildcfg.h
+++ b/bluetooth/bdroid_buildcfg.h
@@ -17,7 +17,25 @@
 #ifndef _BDROID_BUILDCFG_H
 #define _BDROID_BUILDCFG_H
 
-#define BTM_DEF_LOCAL_NAME "Xperia X"
+#if !defined(OS_GENERIC)
+#include <cutils/properties.h>
+#include <string.h>
+
+static inline const char* getBTDefaultName()
+{
+    char device[PROPERTY_VALUE_MAX];
+    property_get("ro.boot.hardware", device, "");
+
+    if (!strcmp("suzu", device)) {
+        return "Xperia X";
+    }
+
+    return "Xperia";
+}
+
+#define BTM_DEF_LOCAL_NAME getBTDefaultName()
+#endif // OS_GENERIC
+
 #define BTM_WBS_INCLUDED TRUE
 #define BTIF_HF_WBS_PREFERRED TRUE
 #define BLE_VND_INCLUDED TRUE


### PR DESCRIPTION
Use ro.boot.hardware property for BT device name.

The OS_GENERIC flag is required due to this:
https://android.googlesource.com/platform/system/bt/+/android-7.0.0_r1/osi/Android.mk#147
https://android.googlesource.com/platform/system/bt/+/android-7.0.0_r1/osi/include/properties.h#21

Signed-off-by: Humberto Borba <humberos@gmail.com>