### PR TITLE
loire: Tune rqbalance for linear core scaling in normal

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -8,7 +8,7 @@ rqbalance.low.balance_level=80
 rqbalance.low.up_threshold=100 200 300 800 900 4294967295
 rqbalance.low.down_threshold=0 75 175 275 775 875
 
-cpuquiet.normal.min_cpus=4
+cpuquiet.normal.min_cpus=2
 cpuquiet.normal.max_cpus=6
 rqbalance.normal.balance_level=40
 rqbalance.normal.up_threshold=50 100 150 400 450 4294967295


### PR DESCRIPTION
RQBalance has a special management algorithm for HMP SoC
which manages BIG cores sligthly differently from LITTLE
ones.

When we try to up 4 LITTLE cores, it will instead upcore
2 LITTLE and one BIG, since the computational power of
the BIG ones is more than 2x the LITTLEs.
It will then upcore one more LITTLE if computational power
is still not enough.

Setting the min cores to a number that is equal to MAX
of LITTLE cluster cores, we are breaking this behavior
resulting in a less efficient and not (power)linear
up/downcore management, hence, the minimum cores to make
the mechanism to work efficiently is 2 on Kitakami (MSM8994).