### PR TITLE
sony: loire: Optimal dex2oat threads for faster app installation

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -129,3 +129,8 @@ PRODUCT_PROPERTY_OVERRIDES += \
     ro.qti.sensors.tilt_detector=false \
     ro.qti.sensors.dpc=false \
     ro.qti.sensors.wu=true
+
+# Optimal dex2oat threads for faster app installation
+PRODUCT_PROPERTY_OVERRIDES += \
+    ro.sys.fw.dex2oat_thread_count=4 \
+    dalvik.vm.dex2oat-threads=4


### PR DESCRIPTION
This patch increases dex2oat threads to 4 for faster app installation.

Signed-off-by: Humberto Borba <humberos@gmail.com>