### PR TITLE
fstab: Allow recovery to use the misc partition

### DIFF
--- a/rootdir/fstab.loire
+++ b/rootdir/fstab.loire
@@ -8,6 +8,7 @@
 /dev/block/bootdevice/by-name/boot         /boot        emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/FOTAKernel   /recovery    emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/config       /persistent  emmc    defaults                                                      defaults
+/dev/block/bootdevice/by-name/apps_log     /misc        emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/modem        /firmware    vfat    ro,shortname=lower,uid=1000,gid=1000,dmask=227,fmask=337,context=u:object_r:firmware_file:s0 wait
 /dev/block/bootdevice/by-name/persist      /persist     ext4    nosuid,nodev,barrier=1,data=ordered,nodelalloc,nomblk_io_submit,errors=panic wait,notrim
 


### PR DESCRIPTION
Android Nougat changed how it communicates with the recovery
partition. Until now the recovery commands had been written
to the /cache partition, but this has changed. Now recovery
writes to the /misc partition.

Fortunately for loire devices we actually have
an empty and unused /apps_log partition we can use.

Signed-off-by: Adam Farden <adam@farden.cz>