### PR TITLE
Configure Zram on loire devices

### DIFF
--- a/rootdir/fstab.loire
+++ b/rootdir/fstab.loire
@@ -14,3 +14,4 @@
 
 /devices/soc.0/7864900.sdhci/mmc_host/mmc*  auto         auto    nosuid,nodev                                      voldmanaged=sdcard1:auto,encryptable=userdata
 /devices/platform/msm_hsusb_host/usb*       auto         auto    nosuid,nodev                                      voldmanaged=usb:auto
+/dev/block/zram0                            none         swap    defaults                                          zramsize=536870912,notrim

--- a/rootdir/init.loire.rc
+++ b/rootdir/init.loire.rc
@@ -20,6 +20,8 @@ on fs
     symlink /dev/block/platform/soc.0/7824900.sdhci /dev/block/bootdevice
 
     mount_all ./fstab.loire
+    swapon_all ./fstab.loire
+
     restorecon_recursive /persist
     write /sys/kernel/boot_adsp/boot 1
 


### PR DESCRIPTION
This can give a nice performance boost under heavy load

Needs the ZRAM driver upgrade: https://github.com/sonyxperiadev/kernel/pull/895

Signed-off-by: Adam Farden <adam@farden.cz>