### PR TITLE
[master] sony: loire: Add zram options

### DIFF
--- a/rootdir/init.loire.rc
+++ b/rootdir/init.loire.rc
@@ -16,6 +16,12 @@ import init.common.rc
 import init.common.usb.rc
 import init.loire.pwr.rc
 
+on init
+    # write swap memory (zram) options
+    write /sys/block/zram0/comp_algorithm lz4
+    write /sys/block/zram0/max_comp_streams 4
+    write /proc/sys/vm/page-cluster 0
+
 on fs
     symlink /dev/block/platform/soc.0/7824900.sdhci /dev/block/bootdevice
 


### PR DESCRIPTION
1. Set lz4 as default compression algorithm.

2. Increase max_comp_streams from 1 to 4

   Regardless the value passed to this attribute, ZRAM will always
   allocate multiple compression streams - one per online CPUs - thus
   allowing several concurrent compression operations. The number of
   allocated compression streams goes down when some of the CPUs
   become offline. There is no single-compression-stream mode anymore,
   unless you are running a UP system or has only 1 CPU online

3. Set page-cluster to 0 (zero). This means "1 page".

   Also, zero disables swap readahead completely.

   Page-cluster controls the number of pages up to which consecutive pages
   are read in from swap in a single attempt. This is the swap counterpart
   to page cache readahead.
   The mentioned consecutivity is not in terms of virtual/physical addresses,
   but consecutive on swap space - that means they were swapped out together.

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: Ifa99270cb11a3593b592aa255345b4d626328046