### PR TITLE
init: add wifi mac address path to macaddrsetup

### DIFF
--- a/rootdir/init.loire.rc
+++ b/rootdir/init.loire.rc
@@ -81,7 +81,7 @@ on boot
     write /dev/cpuset/camera-daemon/cpus 0-3
 
 # OSS WLAN and BT MAC setup
-service macaddrsetup /system/bin/macaddrsetup
+service macaddrsetup /system/bin/macaddrsetup /sys/devices/soc.0/bcmdhd_wlan.114/macaddr
     user root
     disabled
     oneshot


### PR DESCRIPTION
this is needed in order to let macaddrsetup into which file it should
write the wifi mac address.