### PR TITLE
BRCM BT FM

### DIFF
--- a/rootdir/init.loire.rc
+++ b/rootdir/init.loire.rc
@@ -152,7 +152,6 @@ service uim /system/bin/brcm-uim-sysfs
     user root
     group bluetooth net_bt_admin net_bt
     writepid /dev/cpuset/system-background/tasks
-    disabled
 
 on property:vold.post_fs_data_done=1
     # Generate Bluetooth MAC address file only when /data is ready

--- a/rootdir/system/etc/bluetooth/bt_vendor.conf
+++ b/rootdir/system/etc/bluetooth/bt_vendor.conf
@@ -29,3 +29,13 @@ LpmUseBluesleep=true
 
 #Set to true if bd address was programmed into firmware using OTP
 UseControllerBdaddr=false
+
+# Enable debugging (add values below to enable multiple options)
+# enable logging in driver for init/release driver      : 1
+# enable logging in driver for open                     : 2
+# enable logging in driver for close                    : 4
+# enable logging in driver for Tx                       : 8
+# enable logging in driver for Rx                       : 16
+DBG_BT_DRV = 31
+DBG_LDISC_DRV = 31
+DBG_FM_DRV = 31

--- a/rootdir/ueventd.loire.rc
+++ b/rootdir/ueventd.loire.rc
@@ -142,3 +142,6 @@
 /sys/devices/system/cpu/cpuquiet/rqbalance/balance_level             0660 system system
 /sys/devices/system/cpu/cpuquiet/rqbalance/nr_run_thresholds         0660 system system
 /sys/devices/system/cpu/cpuquiet/rqbalance/nr_down_run_thresholds    0660 system system
+
+# BT/FM/ANT+ V4L2
+/dev/brcm_bt_drv          0660   bluetooth  net_bt_stack


### PR DESCRIPTION
Those patches are logically required for BRCM BT FM.

To do: check the correct /dev/radio0 permission