### PR TITLE
sony: loire: init: Label UIM service

### DIFF
--- a/rootdir/init.loire.rc
+++ b/rootdir/init.loire.rc
@@ -151,6 +151,7 @@ service uim /system/bin/brcm-uim-sysfs
     class late_start
     user root
     group bluetooth net_bt_admin net_bt
+    seclabel u:r:uim:s0
     writepid /dev/cpuset/system-background/tasks
 
 on property:vold.post_fs_data_done=1


### PR DESCRIPTION
It is required for sepolicy.

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: Ib21b3608f3e6d696be14b11dbd8286e49d23acdb