### PR TITLE
sony: loire: Fix swap mount process

### DIFF
--- a/rootdir/init.loire.rc
+++ b/rootdir/init.loire.rc
@@ -20,10 +20,12 @@ on fs
     symlink /dev/block/platform/soc.0/7824900.sdhci /dev/block/bootdevice
 
     mount_all ./fstab.loire
-    swapon_all ./fstab.loire
 
     restorecon_recursive /persist
     write /sys/kernel/boot_adsp/boot 1
+
+on post-fs
+    swapon_all ./fstab.loire
 
 on boot
     # Bluetooth


### PR DESCRIPTION
For some reason the fs_mgr is showing the mount error for zram (swap).
[   13.402500] fs_mgr: mkswap failed for /dev/block/zram0

So, move the swap mount process to "on post-fs" stage and get it fixed.
[   13.810523] Adding 524284k swap on /dev/block/zram0.  Priority:-1 extents:1 across:524284k SS

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: Ifbf55344e3ebb0f161f8c5ced621e720661b53ba