### PR TITLE
[master] sony: loire: init: Fix macaddress sysfs

### DIFF
--- a/rootdir/init.loire.rc
+++ b/rootdir/init.loire.rc
@@ -26,8 +26,8 @@ on fs
     write /sys/kernel/boot_adsp/boot 1
 
 on boot
-    # Bluetooth
-    chown system system /sys/devices/soc/bcmdhd_wlan.114/macaddr
+    # WLAN and BT MAC
+    chown system system /sys/devices/soc/soc:bcmdhd_wlan/macaddr
 
     # Cover mode
     chown system system /sys/devices/virtual/input/clearpad/cover_mode_enabled
@@ -84,7 +84,7 @@ on boot
     write /dev/cpuset/camera-daemon/cpus 0-3
 
 # OSS WLAN and BT MAC setup
-service macaddrsetup /system/bin/macaddrsetup /sys/devices/soc/bcmdhd_wlan.114/macaddr
+service macaddrsetup /system/bin/macaddrsetup /sys/devices/soc/soc:bcmdhd_wlan/macaddr
     class core
     user system
     group system bluetooth


### PR DESCRIPTION
it is required on 3.18 kernel.

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I7b27f069ab8f90d6b4b61eb475e1d327b5c5b31e