### PR TITLE
[master] sony: loire: Add androidboot.bootdevice to cmdline

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -39,6 +39,7 @@ BOARD_RAMDISK_OFFSET     := 0x02000000
 
 BOARD_KERNEL_CMDLINE += console=ttyHSL0,115200,n8
 BOARD_KERNEL_CMDLINE += lpm_levels.sleep_disabled=1
+BOARD_KERNEL_CMDLINE += androidboot.bootdevice=7824900.sdhci
 
 BOARD_MKBOOTIMG_ARGS := --ramdisk_offset $(BOARD_RAMDISK_OFFSET) --tags_offset $(BOARD_KERNEL_TAGS_OFFSET)
 


### PR DESCRIPTION
It is expected from sdhci driver@3.18.

Signed-off-by: Humberto Borba <humberos@gmail.com>