### PR TITLE
loire: use correct flag nfc for android-7.1.1

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -79,7 +79,7 @@ BOARD_CUSTOM_BT_CONFIG := $(PLATFORM_COMMON_PATH)/bluetooth/vnd_generic.txt
 TARGET_PER_MGR_ENABLED := true
 
 # NFC
-NFC_NXP_CHIP_TYPE := PN547C2
+NXP_CHIP_TYPE := PN547C2
 
 # FM definitions for Broadcom solution
 BOARD_HAVE_ALTERNATE_FM := true


### PR DESCRIPTION
following marling config https://android.googlesource.com/device/google/marlin/+/android-7.1.1_r8/marlin/BoardConfig.mk#200

Signed-off-by: David Viteri <davidteri91@gmail.com>