### PR TITLE
loire: audio: remove PCM_OFFLOAD ids

### DIFF
--- a/rootdir/system/etc/audio_platform_info.xml
+++ b/rootdir/system/etc/audio_platform_info.xml
@@ -36,14 +36,6 @@
         <device name="AUDIO_DEVICE_IN_BACK_MIC" interface="TERT_MI2S" codec_type="internal"/>
     </interface_names>
     <pcm_ids>
-        <usecase name="USECASE_AUDIO_PLAYBACK_OFFLOAD2" type="out" id="24"/>
-        <usecase name="USECASE_AUDIO_PLAYBACK_OFFLOAD3" type="out" id="27"/>
-        <usecase name="USECASE_AUDIO_PLAYBACK_OFFLOAD4" type="out" id="28"/>
-        <usecase name="USECASE_AUDIO_PLAYBACK_OFFLOAD5" type="out" id="29"/>
-        <usecase name="USECASE_AUDIO_PLAYBACK_OFFLOAD6" type="out" id="30"/>
-        <usecase name="USECASE_AUDIO_PLAYBACK_OFFLOAD7" type="out" id="31"/>
-        <usecase name="USECASE_AUDIO_PLAYBACK_OFFLOAD8" type="out" id="32"/>
-        <usecase name="USECASE_AUDIO_PLAYBACK_OFFLOAD9" type="out" id="33"/>
         <usecase name="USECASE_VOICEMMODE1_CALL" type="in" id="34"/>
         <usecase name="USECASE_VOICEMMODE1_CALL" type="out" id="34"/>
         <usecase name="USECASE_VOICEMMODE2_CALL" type="in" id="35"/>


### PR DESCRIPTION
PCM_OFFLOAD is currently not supported by aosp and it's CAF

02-01 23:28:42.062   455   455 E platform_info: process_pcm_id: usecase USECASE_AUDIO_PLAYBACK_OFFLOAD2 in /system/etc/audio_platform_info.xml not found!
02-01 23:28:42.062   455   455 E platform_info: process_pcm_id: usecase USECASE_AUDIO_PLAYBACK_OFFLOAD3 in /system/etc/audio_platform_info.xml not found!
02-01 23:28:42.062   455   455 E platform_info: process_pcm_id: usecase USECASE_AUDIO_PLAYBACK_OFFLOAD4 in /system/etc/audio_platform_info.xml not found!
02-01 23:28:42.062   455   455 E platform_info: process_pcm_id: usecase USECASE_AUDIO_PLAYBACK_OFFLOAD5 in /system/etc/audio_platform_info.xml not found!
02-01 23:28:42.062   455   455 E platform_info: process_pcm_id: usecase USECASE_AUDIO_PLAYBACK_OFFLOAD6 in /system/etc/audio_platform_info.xml not found!
02-01 23:28:42.062   455   455 E platform_info: process_pcm_id: usecase USECASE_AUDIO_PLAYBACK_OFFLOAD7 in /system/etc/audio_platform_info.xml not found!
02-01 23:28:42.062   455   455 E platform_info: process_pcm_id: usecase USECASE_AUDIO_PLAYBACK_OFFLOAD8 in /system/etc/audio_platform_info.xml not found!
02-01 23:28:42.062   455   455 E platform_info: process_pcm_id: usecase USECASE_AUDIO_PLAYBACK_OFFLOAD9 in /system/etc/audio_platform_info.xml not found!

Signed-off-by: David Viteri <davidteri91@gmail.com>