### PR TITLE
loire: Add /dsp partition

### DIFF
--- a/rootdir/fstab.loire
+++ b/rootdir/fstab.loire
@@ -9,6 +9,7 @@
 /dev/block/bootdevice/by-name/FOTAKernel   /recovery    emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/config       /persistent  emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/apps_log     /misc        emmc    defaults                                                      defaults
+/dev/block/bootdevice/by-name/dsp          /dsp         ext4    nosuid,nodev,barrier=1                                        wait
 /dev/block/bootdevice/by-name/modem        /firmware    vfat    ro,shortname=lower,uid=1000,gid=1000,dmask=227,fmask=337,context=u:object_r:firmware_file:s0 wait
 /dev/block/bootdevice/by-name/persist      /persist     ext4    nosuid,nodev,barrier=1,data=ordered,nodelalloc,nomblk_io_submit,errors=panic wait,notrim
 


### PR DESCRIPTION
* Dsp is used to dynamic load audio module

Change-Id: Iff6bc8bcc4dca18c6210dff6fea4e997f8fa9755