### PR TITLE
loire: fix macaddr path

### DIFF
--- a/rootdir/init.loire.rc
+++ b/rootdir/init.loire.rc
@@ -27,7 +27,7 @@ on fs
 
 on boot
     # Bluetooth
-    chown system system /sys/devices/soc.0/bcmdhd_wlan.115/macaddr
+    chown system system /sys/devices/soc.0/bcmdhd_wlan.116/macaddr
 
     # Cover mode
     chown system system /sys/devices/virtual/input/clearpad/cover_mode_enabled
@@ -84,7 +84,7 @@ on boot
     write /dev/cpuset/camera-daemon/cpus 0-3
 
 # OSS WLAN and BT MAC setup
-service macaddrsetup /system/bin/macaddrsetup /sys/devices/soc.0/bcmdhd_wlan.115/macaddr
+service macaddrsetup /system/bin/macaddrsetup /sys/devices/soc.0/bcmdhd_wlan.116/macaddr
     class core
     user system
     group system bluetooth


### PR DESCRIPTION
needed after recent DT changes in kernel for loire

Signed-off-by: David Viteri <davidteri91@gmail.com>