### PR TITLE
loire: fix audio in call

### DIFF
--- a/rootdir/system/etc/audio_platform_info.xml
+++ b/rootdir/system/etc/audio_platform_info.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<!-- Copyright (c) 2015-2016, The Linux Foundation. All rights reserved.         -->
+<!-- Copyright (c) 2015-2016, The Linux Foundation. All rights reserved.    -->
 <!--                                                                        -->
 <!-- Redistribution and use in source and binary forms, with or without     -->
 <!-- modification, are permitted provided that the following conditions are -->
@@ -36,13 +36,12 @@
         <device name="AUDIO_DEVICE_IN_BACK_MIC" interface="TERT_MI2S" codec_type="internal"/>
     </interface_names>
     <pcm_ids>
-        <usecase name="USECASE_VOICEMMODE1_CALL" type="in" id="34"/>
-        <usecase name="USECASE_VOICEMMODE1_CALL" type="out" id="34"/>
-        <usecase name="USECASE_VOICEMMODE2_CALL" type="in" id="35"/>
-        <usecase name="USECASE_VOICEMMODE2_CALL" type="out" id="35"/>
+        <usecase name="USECASE_VOICEMMODE1_CALL" type="in" id="35"/>
+        <usecase name="USECASE_VOICEMMODE1_CALL" type="out" id="35"/>
+        <usecase name="USECASE_VOICEMMODE2_CALL" type="in" id="36"/>
+        <usecase name="USECASE_VOICEMMODE2_CALL" type="out" id="36"/>
     </pcm_ids>
     <tz_names>
         <device name="SND_DEVICE_OUT_SPEAKER" spkr_1_tz_name="wsa881x.0f" spkr_2_tz_name=""/>
     </tz_names>
 </audio_platform_info>
-


### PR DESCRIPTION
correct audio_platform_info for msm8952 tomtom and 8976 tasha sound cards are audio_platform_info_extcodec.xml
see 8952 caf implementation https://source.codeaurora.org/quic/la/platform/hardware/qcom/audio/diff/?h=LA.BR.1.3.3_rb2.14&id=0d28b4a9c06b8f6f9647bfe3e6ff24a38fd52432
see 8976 caf implementation https://source.codeaurora.org/quic/la/platform/hardware/qcom/audio/diff/?h=LA.BR.1.3.3_rb2.14&id=d7691747054a99583e1d4225d37eb631fdb2eceb

both 8952 and 8976 use external_codec

Signed-off-by: David Viteri <davidteri91@gmail.com>