### PR TITLE
sony: loire: Move BT flag

### DIFF
--- a/bluetooth/bdroid_buildcfg.h
+++ b/bluetooth/bdroid_buildcfg.h
@@ -21,8 +21,6 @@
 #include <cutils/properties.h>
 #include <string.h>
 
-#define HCILP_INCLUDED FALSE
-
 static inline const char* getBTDefaultName()
 {
     char device[PROPERTY_VALUE_MAX];
@@ -42,6 +40,7 @@ static inline const char* getBTDefaultName()
 #define BTM_DEF_LOCAL_NAME getBTDefaultName()
 #endif // OS_GENERIC
 
+#define HCILP_INCLUDED FALSE
 #define BTM_WBS_INCLUDED TRUE
 #define BTIF_HF_WBS_PREFERRED TRUE
 #define BLE_VND_INCLUDED TRUE


### PR DESCRIPTION
Move HCILP_INCLUDED out of OS_GENERIC #ifdef .

OS_GENERIC flag was used to fix BTDefaultName at Nougat.

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: Ie12227b649ff087a5ceba955b47d8b84f82706ac