### PR TITLE
sony: loire: Bluetooth unified configuration

### DIFF
--- a/bluetooth/bdroid_buildcfg.h
+++ b/bluetooth/bdroid_buildcfg.h
@@ -39,8 +39,8 @@ inline const char* getBTDefaultName()
 }
 
 #define BTM_DEF_LOCAL_NAME getBTDefaultName()
-#define BTM_WBS_INCLUDED TRUE
-#define BTIF_HF_WBS_PREFERRED TRUE
-#define BLE_VND_INCLUDED TRUE
+
+/* #define BTA_AV_CO_CP_SCMS_T   TRUE */
+#define SDP_AVRCP_1_5   FALSE
 
 #endif


### PR DESCRIPTION
Use same BT configuration from shinano.

BCM devices should use the same configuration since
bluesleep and serial drivers were changed to get BT and FM working
simultaneously.

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I8ede9a0a496306de2b28d86617de6d3bccc96f68