### PR TITLE
[N-MR1] rootdir: audio: add acdb_id mapping for incall speaker

### DIFF
--- a/rootdir/system/etc/audio_platform_info.xml
+++ b/rootdir/system/etc/audio_platform_info.xml
@@ -26,6 +26,9 @@
 <!-- OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN -->
 <!-- IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                          -->
 <audio_platform_info>
+    <acdb_ids>
+        <device name="SND_DEVICE_OUT_VOICE_SPEAKER" acdb_id="135"/>
+    </acdb_ids>
     <bit_width_configs>
         <device name="SND_DEVICE_OUT_SPEAKER" bit_width="24"/>
     </bit_width_configs>


### PR DESCRIPTION
On stock, the device SND_DEVICE_OUT_VOICE_SPEAKER_WSA is the actual incall speaker,
which is calibrated using acdb.
Since that device has a different acdb_id than SND_DEVICE_OUT_VOICE_SPEAKER, this
causes calibration to fail on AOSP, when using .acdb files from stock. This is due to
that acdb_id mismatch
Fix it by mapping SND_DEVICE_OUT_VOICE_SPEAKER on AOSP to the same acdb_id.

Change-Id: I735d649397c5364aa757462462a8f296e638f9d0