### PR TITLE
loire: Configure recovery for USB ConfigFS

### DIFF
--- a/rootdir/init.recovery.loire.rc
+++ b/rootdir/init.recovery.loire.rc
@@ -1,6 +1,8 @@
+import init.common.usb.rc
+
 on fs
     symlink /dev/block/platform/soc/7824900.sdhci /dev/block/bootdevice
+    setprop sys.usb.controller 86000c8.android_usb
 
 on boot
-    write /sys/class/android_usb/android0/idVendor 0FCE
-    write /sys/class/android_usb/android0/idProduct 6${ro.usb.pid_suffix}
+    setprop sys.usb.config adb


### PR DESCRIPTION
following https://github.com/sonyxperiadev/device-sony-tone/commit/6196fb892b9ab721e784c58023e724ce5d1bc00b

Signed-off-by: David Viteri <davidteri91@gmail.com>