### PR TITLE
[LOIRE n-mr1] fstab: Add DSP partition for mount

### DIFF
--- a/rootdir/fstab.loire
+++ b/rootdir/fstab.loire
@@ -8,6 +8,7 @@
 /dev/block/bootdevice/by-name/boot         /boot        emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/FOTAKernel   /recovery    emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/config       /persistent  emmc    defaults                                                      defaults
+/dev/block/bootdevice/by-name/dsp          /dsp         ext4    ro,noatime,nosuid,nodev,barrier=1                             defaults
 /dev/block/bootdevice/by-name/apps_log     /misc        emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/modem        /firmware    vfat    ro,shortname=lower,uid=1000,gid=1000,dmask=227,fmask=337,context=u:object_r:firmware_file:s0 wait
 /dev/block/bootdevice/by-name/persist      /persist     ext4    nosuid,nodev,barrier=1,data=ordered,nodelalloc,nomblk_io_submit,errors=panic wait,notrim


### PR DESCRIPTION
Loire platform needs the DSP partition for the QC
FastRPC daemon to work correctly.