### PR TITLE
[master] sony: loire: sepolicy: Add dsp device to file contexts

### DIFF
--- a/sepolicy_platform/file_contexts
+++ b/sepolicy_platform/file_contexts
@@ -19,6 +19,9 @@
 /dev/block/platform/soc/7824900\.sdhci/by-name/ssd             u:object_r:ssd_device:s0
 /dev/block/bootdevice/by-name/ssd                              u:object_r:ssd_device:s0
 
+/dev/block/platform/soc/7824900\.sdhci/by-name/dsp             u:object_r:adsprpcd_device:s0
+/dev/block/bootdevice/by-name/dsp                              u:object_r:adsprpcd_device:s0
+
 /dev/block/mmcblk0p1                                           u:object_r:trim_area_partition_device:s0
 /dev/block/platform/soc/7824900\.sdhci/by-name/TA              u:object_r:trim_area_partition_device:s0
 /dev/block/bootdevice/by-name/TA                               u:object_r:trim_area_partition_device:s0


### PR DESCRIPTION
It is requires for acdb.

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: Icce0e24ff08988aaca1de3d61d02aa992eb3f431