### PR TITLE
loire: fix block nodes for kernel 3.10

### DIFF
--- a/sepolicy_platform/file_contexts
+++ b/sepolicy_platform/file_contexts
@@ -7,42 +7,41 @@
 /dev/block/mmcblk1                                             u:object_r:sd_device:s0
 /dev/block/mmcblk1p1                                           u:object_r:sd_device:s0
 
-/dev/block/platform/soc/7824900\.sdhci/by-name/modemst1        u:object_r:modem_efs_partition_device:s0
+/dev/block/platform/soc\.0/7824900\.sdhci/by-name/modemst1     u:object_r:modem_efs_partition_device:s0
 /dev/block/bootdevice/by-name/modemst1                         u:object_r:modem_efs_partition_device:s0
 
-/dev/block/platform/soc/7824900\.sdhci/by-name/modemst2        u:object_r:modem_efs_partition_device:s0
+/dev/block/platform/soc\.0/7824900\.sdhci/by-name/modemst2     u:object_r:modem_efs_partition_device:s0
 /dev/block/bootdevice/by-name/modemst2                         u:object_r:modem_efs_partition_device:s0
 
-/dev/block/platform/soc/7824900\.sdhci/by-name/fsg             u:object_r:modem_efs_partition_device:s0
+/dev/block/platform/soc\.0/7824900\.sdhci/by-name/fsg          u:object_r:modem_efs_partition_device:s0
 /dev/block/bootdevice/by-name/fsg                              u:object_r:modem_efs_partition_device:s0
 
-/dev/block/platform/soc/7824900\.sdhci/by-name/ssd             u:object_r:ssd_device:s0
+/dev/block/platform/soc\.0/7824900\.sdhci/by-name/ssd          u:object_r:ssd_device:s0
 /dev/block/bootdevice/by-name/ssd                              u:object_r:ssd_device:s0
 
-/dev/block/platform/soc/7824900\.sdhci/by-name/dsp             u:object_r:adsprpcd_device:s0
+/dev/block/platform/soc\.0/7824900\.sdhci/by-name/dsp          u:object_r:adsprpcd_device:s0
 /dev/block/bootdevice/by-name/dsp                              u:object_r:adsprpcd_device:s0
 
 /dev/block/mmcblk0p1                                           u:object_r:trim_area_partition_device:s0
-/dev/block/platform/soc/7824900\.sdhci/by-name/TA              u:object_r:trim_area_partition_device:s0
+/dev/block/platform/soc\.0/7824900\.sdhci/by-name/TA           u:object_r:trim_area_partition_device:s0
 /dev/block/bootdevice/by-name/TA                               u:object_r:trim_area_partition_device:s0
 
-/dev/block/platform/soc/7824900\.sdhci/by-name/userdata        u:object_r:userdata_block_device:s0
+/dev/block/platform/soc\.0/7824900\.sdhci/by-name/userdata     u:object_r:userdata_block_device:s0
 /dev/block/bootdevice/by-name/userdata                         u:object_r:userdata_block_device:s0
 
-/dev/block/platform/soc/7824900\.sdhci/by-name/boot            u:object_r:boot_block_device:s0
+/dev/block/platform/soc\.0/7824900\.sdhci/by-name/boot         u:object_r:boot_block_device:s0
 /dev/block/bootdevice/by-name/boot                             u:object_r:boot_block_device:s0
 
-/dev/block/platform/soc/7824900\.sdhci/by-name/FOTAKernel      u:object_r:recovery_block_device:s0
+/dev/block/platform/soc\.0/7824900\.sdhci/by-name/FOTAKernel   u:object_r:recovery_block_device:s0
 /dev/block/bootdevice/by-name/FOTAKernel                       u:object_r:recovery_block_device:s0
 
-/dev/block/platform/soc/7824900\.sdhci/by-name/cache           u:object_r:cache_block_device:s0
+/dev/block/platform/soc\.0/7824900\.sdhci/by-name/cache        u:object_r:cache_block_device:s0
 /dev/block/bootdevice/by-name/cache                            u:object_r:cache_block_device:s0
 
-/dev/block/platform/soc/7824900\.sdhci/by-name/apps_log        u:object_r:misc_block_device:s0
+/dev/block/platform/soc\.0/7824900\.sdhci/by-name/apps_log     u:object_r:misc_block_device:s0
 /dev/block/bootdevice/by-name/apps_log                         u:object_r:misc_block_device:s0
-/dev/block/bootdevice/by-name/misc                             u:object_r:misc_block_device:s0
 
-/dev/block/platform/soc/7824900\.sdhci/by-name/persist         u:object_r:persist_block_device:s0
+/dev/block/platform/soc\.0/7824900\.sdhci/by-name/persist      u:object_r:persist_block_device:s0
 /dev/block/bootdevice/by-name/persist                          u:object_r:persist_block_device:s0
 
 /dev/block/zram0                                               u:object_r:swap_block_device:s0


### PR DESCRIPTION
on kernel 3.10 dev block nodes are soc.0 not soc

Signed-off-by: David Viteri <davidteri91@gmail.com>