### PR TITLE
[master] sony: loire: Increase max number of compression streams

### DIFF
--- a/rootdir/init.loire.rc
+++ b/rootdir/init.loire.rc
@@ -16,6 +16,9 @@ import init.common.rc
 import init.common.usb-legacy.rc
 import init.loire.pwr.rc
 
+on init
+    write /sys/block/zram0/max_comp_streams 6
+
 on fs
     symlink /dev/block/platform/soc/7824900.sdhci /dev/block/bootdevice
 


### PR DESCRIPTION
Regardless the value passed to this attribute, ZRAM will always
allocate multiple compression streams - one per online CPUs - thus
allowing several concurrent compression operations. The number of
allocated compression streams goes down when some of the CPUs
become offline. There is no single-compression-stream mode anymore,
unless you are running a UP system or has only 1 CPU online.

Change-Id: I8ff3fef28d48aec1715be687d961cb11628dab53
Signed-off-by: Humberto Borba <humberos@gmail.com>