### PR TITLE
loire: fix wled:backlight path

### DIFF
--- a/rootdir/ueventd.loire.rc
+++ b/rootdir/ueventd.loire.rc
@@ -120,8 +120,8 @@
 /sys/devices/soc/7af6000.i2c/i2c-6/6-0028  send_cmd      0200 nfc nfc
 
 # LED
-/sys/devices/soc/03-qcom,leds-d800/leds/wled:backlight max_brightness 0664 system system
-/sys/devices/soc/03-qcom,leds-d800/leds/wled:backlight brightness     0664 system system
+/sys/devices/soc/200f000.qcom,spmi/spmi-0/spmi0-03/200f000.qcom,spmi:qcom,pmi8950@3:qcom,leds@d800/leds/wled:backlight max_brightness 0664 system system
+/sys/devices/soc/200f000.qcom,spmi/spmi-0/spmi0-03/200f000.qcom,spmi:qcom,pmi8950@3:qcom,leds@d800/leds/wled:backlight brightness     0664 system system
 /sys/devices/soc/7af6000.i2c/i2c-6/6-0042/leds/led:* max_brightness   0664 system system
 /sys/devices/soc/7af6000.i2c/i2c-6/6-0042/leds/led:* brightness       0664 system system
 /sys/devices/soc/7af6000.i2c/i2c-6/6-0042/leds/led:* blink            0664 system system


### PR DESCRIPTION
lrwxrwxrwx 1 root root 0 2017-08-14 09:32 wled:backlight -> ../../devices/soc/200f000.qcom,spmi/spmi-0/spmi0-03/200f000.qcom,spmi:qcom,pmi8950@3:qcom,leds@d800/leds/wled:backlight

Signed-off-by: David Viteri <davidteri91@gmail.com>