### PR TITLE
loire: wifi: use platform specific wpa and p2p overlays

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -17,7 +17,6 @@ PLATFORM_COMMON_PATH := device/sony/loire
 
 $(call inherit-product, device/sony/common/common.mk)
 $(call inherit-product, $(SRC_TARGET_DIR)/product/core_64_bit.mk)
-$(call inherit-product, hardware/broadcom/wlan/bcmdhd/config/config-bcm.mk)
 
 SOMC_PLATFORM := loire
 
@@ -49,6 +48,11 @@ PRODUCT_COPY_FILES += \
 # RQBalance-PowerHAL configuration
 PRODUCT_COPY_FILES += \
     $(SONY_ROOT)/system/etc/rqbalance_config.xml:system/etc/rqbalance_config.xml
+
+# WLAN
+PRODUCT_COPY_FILES += \
+    $(SONY_ROOT)/system/etc/p2p_supplicant_overlay.conf:system/etc/wifi/p2p_supplicant_overlay.conf \
+    $(SONY_ROOT)/system/etc/wpa_supplicant_overlay.conf:system/etc/wifi/wpa_supplicant_overlay.conf
 
 # Device Specific Hardware
 PRODUCT_COPY_FILES += \

--- a/rootdir/system/etc/p2p_supplicant_overlay.conf
+++ b/rootdir/system/etc/p2p_supplicant_overlay.conf
@@ -1,0 +1,4 @@
+disable_scan_offload=1
+p2p_no_go_freq=5170-5740
+p2p_search_delay=0
+no_ctrl_interface=

--- a/rootdir/system/etc/wpa_supplicant_overlay.conf
+++ b/rootdir/system/etc/wpa_supplicant_overlay.conf
@@ -1,0 +1,4 @@
+disable_scan_offload=1
+p2p_disabled=1
+filter_rssi=-75
+no_ctrl_interface=


### PR DESCRIPTION
loire needs customized overlays to remove wowlan, which causes device to crash randomly while booting.
This is based on the same modifications done for tone
https://github.com/sonyxperiadev/device-sony-tone/commit/65d4ec3315ecfae662f16e82b020567da69c7a0a