### PR TITLE
rootdir: init: set wifi user for bcmdhd firmware path

### DIFF
--- a/rootdir/init.loire.rc
+++ b/rootdir/init.loire.rc
@@ -31,6 +31,7 @@ on fs
 on boot
     # WLAN and BT MAC
     chown system system /sys/devices/soc/soc:bcmdhd_wlan/macaddr
+    chown wifi wifi /sys/module/bcmdhd/parameters/firmware_path
 
     # Cover mode
     chown system system /sys/devices/virtual/input/clearpad/cover_mode_enabled


### PR DESCRIPTION
Android can not write fw to the sysfs node due to missing permissions:
E android.hardware.wifi@1.0-service: Failed to open wlan fw path param: Permission denied
By setting the user to wifi, fw can be written and wifi starts properly.
Also, fix a small comment issue where wifi related command was annotated by Bluetooth.