### PR TITLE
Pin .vdex files as well

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -21,9 +21,13 @@
     <!-- Default list of files pinned by the Pinner Service -->
     <string-array translatable="false" name="config_defaultPinnerServiceFiles">
         <item>"/system/framework/arm64/boot-framework.oat"</item>
+        <item>"/system/framework/arm64/boot-framework.vdex"</item>
         <item>"/system/framework/oat/arm64/services.odex"</item>
+        <item>"/system/framework/oat/arm64/services.vdex"</item>
         <item>"/system/framework/arm64/boot.oat"</item>
+        <item>"/system/framework/arm64/boot.vdex"</item>
         <item>"/system/framework/arm64/boot-core-libart.oat"</item>
+        <item>"/system/framework/arm64/boot-core-libart.vdex"</item>
    </string-array>
 
 </resources>


### PR DESCRIPTION
.vdex files have been added to allow pre-verified dex.  The pinner
service needs to take this in account when pinning.  Add pinning of
appropriate system .vdex files on device.

Bug 33168521
Test:  Tested manually by confirming pinning is successful

Change-Id: Ice2c3f0ec0b314963fb136793d9fa36ecba58490