### PR TITLE
[LOIRE] media: Fix for AOSP-only profiles

### DIFF
--- a/rootdir/system/etc/media_profiles_V1_0.xml
+++ b/rootdir/system/etc/media_profiles_V1_0.xml
@@ -115,19 +115,6 @@
                    channels="1" />
         </EncoderProfile>
 
-        <EncoderProfile quality="vga" fileFormat="mp4" duration="30">
-            <Video codec="h264"
-                   bitRate="2000000"
-                   width="640"
-                   height="480"
-                   frameRate="30" />
-
-            <Audio codec="aac"
-                   bitRate="156000"
-                   sampleRate="48000"
-                   channels="2" />
-        </EncoderProfile>
-
         <EncoderProfile quality="timelapseqcif" fileFormat="mp4" duration="30">
             <Video codec="h264"
                    bitRate="192000"
@@ -186,6 +173,7 @@
                    width="1920"
                    height="1080"
                    frameRate="30" />
+
             <!-- audio setting is ignored -->
             <Audio codec="aac"
                    bitRate="156000"
@@ -325,6 +313,7 @@
                    width="1920"
                    height="1080"
                    frameRate="30" />
+
             <!-- audio setting is ignored -->
             <Audio codec="aac"
                    bitRate="156000"
@@ -365,14 +354,8 @@
         minFrameHeight="144" maxFrameHeight="1088"
         minFrameRate="15" maxFrameRate="30" />
 
-    <VideoEncoderCap name="h265" enabled="true"
-        minBitRate="64000" maxBitRate="100000000"
-        minFrameWidth="176" maxFrameWidth="3840"
-        minFrameHeight="144" maxFrameHeight="2160"
-        minFrameRate="15" maxFrameRate="30" />
-
     <AudioEncoderCap name="aac" enabled="true"
-        minBitRate="8000" maxBitRate="96000"
+        minBitRate="8000" maxBitRate="156000"
         minSampleRate="8000" maxSampleRate="48000"
         minChannels="1" maxChannels="2" />
 
@@ -395,11 +378,6 @@
         minBitRate="5525" maxBitRate="12200"
         minSampleRate="8000" maxSampleRate="8000"
         minChannels="1" maxChannels="1" />
-
-    <AudioEncoderCap name="lpcm" enabled="true"
-        minBitRate="768000" maxBitRate="4608000"
-        minSampleRate="48000" maxSampleRate="48000"
-        minChannels="1" maxChannels="6" />
 
     <!--
         FIXME:


### PR DESCRIPTION
VGA profile and h265 encoder are not present on AOSP.
While at it, increase the maximum AAC bitrate.