### PR TITLE
loire: add sys.usb.rndis.func.name prop

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -143,4 +143,5 @@ PRODUCT_PROPERTY_OVERRIDES += \
 
 # USB controller setup
 PRODUCT_PROPERTY_OVERRIDES += \
-    sys.usb.controller=msm_hsusb
+    sys.usb.controller=msm_hsusb \
+    sys.usb.rndis.func.name=rndis_bam


### PR DESCRIPTION
needed for USB tethering usecase

Signed-off-by: David Viteri <davidteri91@gmail.com>