### PR TITLE
loire: label ramdump partition

### DIFF
--- a/sepolicy_platform/file_contexts
+++ b/sepolicy_platform/file_contexts
@@ -48,4 +48,7 @@
 /dev/block/platform/soc/7824900\.sdhci/by-name/oem             u:object_r:system_block_device:s0
 /dev/block/bootdevice/by-name/oem                              u:object_r:system_block_device:s0
 
+/dev/block/platform/soc/7824900\.sdhci/by-name/rdimage         u:object_r:rdimage_block_device:s0
+/dev/block/bootdevice/by-name/rdimage                          u:object_r:rdimage_block_device:s0
+
 /dev/block/zram0                                               u:object_r:swap_block_device:s0


### PR DESCRIPTION
This is used by the common rdclean.sh rules, see device/sony/common
for the details.

Signed-off-by: Oleksiy Avramchenko <oleksiy.avramchenko@sony.com>