### PR TITLE
[master] loire: Migrate audio configs to platform repo

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -26,7 +26,9 @@ SONY_ROOT := $(PLATFORM_COMMON_PATH)/rootdir
 # Audio
 PRODUCT_COPY_FILES += \
     $(SONY_ROOT)/system/etc/aanc_tuning_mixer_wcd9335.txt:system/etc/aanc_tuning_mixer_wcd9335.txt \
-    $(SONY_ROOT)/system/etc/audio_platform_info.xml:system/etc/audio_platform_info.xml
+    $(SONY_ROOT)/system/etc/audio_platform_info.xml:system/etc/audio_platform_info.xml \
+    $(SONY_ROOT)/system/etc/audio_policy.conf:system/etc/audio_policy.conf \
+    $(SONY_ROOT)/system/etc/mixer_paths.xml:system/etc/mixer_paths.xml
 
 # Media
 PRODUCT_COPY_FILES += \

--- a/rootdir/system/etc/audio_policy.conf
+++ b/rootdir/system/etc/audio_policy.conf
@@ -1,0 +1,145 @@
+# Global configuration section:
+# - lists input and output devices always present on the device
+# as well as the output device selected by default.
+# Devices are designated by a string that corresponds to the enum in audio.h
+# - defines whether the speaker output path uses DRC
+# "TRUE" means DRC is enabled, "FALSE" or omission means DRC isn't used.
+
+global_configuration {
+  attached_output_devices AUDIO_DEVICE_OUT_EARPIECE|AUDIO_DEVICE_OUT_SPEAKER|AUDIO_DEVICE_OUT_TELEPHONY_TX
+  default_output_device AUDIO_DEVICE_OUT_SPEAKER
+  attached_input_devices AUDIO_DEVICE_IN_BUILTIN_MIC|AUDIO_DEVICE_IN_BACK_MIC|AUDIO_DEVICE_IN_REMOTE_SUBMIX|AUDIO_DEVICE_IN_TELEPHONY_RX|AUDIO_DEVICE_IN_FM_TUNER
+}
+
+# audio hardware module section: contains descriptors for all audio hw modules present on the
+# device. Each hw module node is named after the corresponding hw module library base name.
+# For instance, "primary" corresponds to audio.primary.<device>.so.
+# The "primary" module is mandatory and must include at least one output with
+# AUDIO_OUTPUT_FLAG_PRIMARY flag.
+# Each module descriptor contains one or more output profile descriptors and zero or more
+# input profile descriptors. Each profile lists all the parameters supported by a given output
+# or input stream category.
+# The "channel_masks", "formats", "devices" and "flags" are specified using strings corresponding
+# to enums in audio.h and audio_policy.h. They are concatenated by use of "|" without space or "\n".
+
+audio_hw_modules {
+  primary {
+    outputs {
+      primary {
+        sampling_rates 44100|48000
+        channel_masks AUDIO_CHANNEL_OUT_STEREO
+        formats AUDIO_FORMAT_PCM_16_BIT
+        devices AUDIO_DEVICE_OUT_EARPIECE|AUDIO_DEVICE_OUT_SPEAKER|AUDIO_DEVICE_OUT_WIRED_HEADSET|AUDIO_DEVICE_OUT_WIRED_HEADPHONE|AUDIO_DEVICE_OUT_ALL_SCO|AUDIO_DEVICE_OUT_AUX_DIGITAL
+        flags AUDIO_OUTPUT_FLAG_FAST|AUDIO_OUTPUT_FLAG_PRIMARY
+      }
+      raw {
+        sampling_rates 8000|11025|12000|16000|22050|24000|32000|44100|48000
+        channel_masks AUDIO_CHANNEL_OUT_STEREO
+        formats AUDIO_FORMAT_PCM_16_BIT
+        devices AUDIO_DEVICE_OUT_EARPIECE|AUDIO_DEVICE_OUT_SPEAKER|AUDIO_DEVICE_OUT_WIRED_HEADSET|AUDIO_DEVICE_OUT_WIRED_HEADPHONE|AUDIO_DEVICE_OUT_ALL_SCO|AUDIO_DEVICE_OUT_AUX_DIGITAL
+        flags AUDIO_OUTPUT_FLAG_FAST|AUDIO_OUTPUT_FLAG_RAW
+      }
+      deep_buffer {
+         sampling_rates 8000|11025|12000|16000|22050|24000|32000|44100|48000
+         channel_masks AUDIO_CHANNEL_OUT_STEREO
+         formats AUDIO_FORMAT_PCM_16_BIT
+         devices AUDIO_DEVICE_OUT_SPEAKER|AUDIO_DEVICE_OUT_EARPIECE|AUDIO_DEVICE_OUT_WIRED_HEADSET|AUDIO_DEVICE_OUT_WIRED_HEADPHONE|AUDIO_DEVICE_OUT_ALL_SCO|AUDIO_DEVICE_OUT_AUX_DIGITAL
+         flags AUDIO_OUTPUT_FLAG_DEEP_BUFFER
+      }
+      hdmi {
+        sampling_rates 44100|48000
+        channel_masks dynamic
+        formats AUDIO_FORMAT_PCM_16_BIT
+        devices AUDIO_DEVICE_OUT_AUX_DIGITAL
+        flags AUDIO_OUTPUT_FLAG_DIRECT
+      }
+      compress_offload {
+        sampling_rates 8000|11025|12000|16000|22050|24000|32000|44100|48000
+        channel_masks AUDIO_CHANNEL_OUT_MONO|AUDIO_CHANNEL_OUT_STEREO
+        formats AUDIO_FORMAT_MP3|AUDIO_FORMAT_AAC_LC|AUDIO_FORMAT_AAC_HE_V1|AUDIO_FORMAT_AAC_HE_V2
+        devices AUDIO_DEVICE_OUT_SPEAKER|AUDIO_DEVICE_OUT_WIRED_HEADSET|AUDIO_DEVICE_OUT_WIRED_HEADPHONE
+        flags AUDIO_OUTPUT_FLAG_DIRECT|AUDIO_OUTPUT_FLAG_COMPRESS_OFFLOAD|AUDIO_OUTPUT_FLAG_NON_BLOCKING
+      }
+      voice_tx {
+        sampling_rates 8000|16000|48000
+        channel_masks AUDIO_CHANNEL_OUT_STEREO|AUDIO_CHANNEL_OUT_MONO
+        formats AUDIO_FORMAT_PCM_16_BIT
+        devices AUDIO_DEVICE_OUT_TELEPHONY_TX
+      }
+    }
+    inputs {
+      primary {
+        sampling_rates 8000|11025|12000|16000|22050|24000|32000|44100|48000
+        channel_masks AUDIO_CHANNEL_IN_MONO|AUDIO_CHANNEL_IN_STEREO|AUDIO_CHANNEL_IN_FRONT_BACK
+        formats AUDIO_FORMAT_PCM_16_BIT|AUDIO_FORMAT_PCM_8_24_BIT
+        devices AUDIO_DEVICE_IN_BUILTIN_MIC|AUDIO_DEVICE_IN_WIRED_HEADSET|AUDIO_DEVICE_IN_BLUETOOTH_SCO_HEADSET|AUDIO_DEVICE_IN_VOICE_CALL|AUDIO_DEVICE_IN_BACK_MIC|AUDIO_DEVICE_IN_FM_TUNER
+      }
+      voice_rx {
+        sampling_rates 8000|16000|48000
+        channel_masks AUDIO_CHANNEL_IN_STEREO|AUDIO_CHANNEL_IN_MONO
+        formats AUDIO_FORMAT_PCM_16_BIT
+        devices AUDIO_DEVICE_IN_TELEPHONY_RX
+      }
+    }
+  }
+  a2dp {
+    outputs {
+      a2dp {
+        sampling_rates 44100
+        channel_masks AUDIO_CHANNEL_OUT_STEREO
+        formats AUDIO_FORMAT_PCM_16_BIT
+        devices AUDIO_DEVICE_OUT_ALL_A2DP
+      }
+    }
+    inputs {
+      a2dp {
+        sampling_rates 44100|48000
+        channel_masks AUDIO_CHANNEL_IN_MONO|AUDIO_CHANNEL_IN_STEREO
+        formats AUDIO_FORMAT_PCM_16_BIT
+        devices AUDIO_DEVICE_IN_BLUETOOTH_A2DP
+      }
+    }
+  }
+  usb {
+    outputs {
+      usb_accessory {
+        sampling_rates 44100
+        channel_masks AUDIO_CHANNEL_OUT_STEREO
+        formats AUDIO_FORMAT_PCM_16_BIT
+        devices AUDIO_DEVICE_OUT_USB_ACCESSORY
+      }
+      usb_device {
+        sampling_rates dynamic
+        channel_masks dynamic
+        formats dynamic
+        devices AUDIO_DEVICE_OUT_USB_DEVICE
+      }
+    }
+    inputs {
+      usb_device {
+        sampling_rates dynamic
+        channel_masks dynamic
+        formats dynamic
+        devices AUDIO_DEVICE_IN_USB_DEVICE
+      }
+    }
+  }
+  r_submix {
+    outputs {
+      submix {
+        sampling_rates 48000
+        channel_masks AUDIO_CHANNEL_OUT_STEREO
+        formats AUDIO_FORMAT_PCM_16_BIT
+        devices AUDIO_DEVICE_OUT_REMOTE_SUBMIX
+      }
+    }
+    inputs {
+      submix {
+        sampling_rates 48000
+        channel_masks AUDIO_CHANNEL_IN_STEREO
+        formats AUDIO_FORMAT_PCM_16_BIT
+        devices AUDIO_DEVICE_IN_REMOTE_SUBMIX
+      }
+    }
+  }
+}

--- a/rootdir/system/etc/mixer_paths.xml
+++ b/rootdir/system/etc/mixer_paths.xml
@@ -1,0 +1,3980 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<mixer>
+    <!-- These are the initial mixer settings -->
+    <ctl name="Voice Rx Device Mute" id="0" value="0" />
+    <ctl name="Voice Rx Device Mute" id="1" value="-1" />
+    <ctl name="Voice Rx Device Mute" id="2" value="20" />
+    <ctl name="Voice Tx Mute" id="0" value="0" />
+    <ctl name="Voice Tx Mute" id="1" value="-1" />
+    <ctl name="Voice Tx Mute" id="2" value="500" />
+    <ctl name="Voice Rx Gain" id="0" value="0" />
+    <ctl name="Voice Rx Gain" id="1" value="-1" />
+    <ctl name="Voice Rx Gain" id="2" value="20" />
+    <ctl name="Voip Tx Mute" id="0" value="0" />
+    <ctl name="Voip Tx Mute" id="1" value="500" />
+    <ctl name="Voip Rx Gain" id="0" value="0" />
+    <ctl name="Voip Rx Gain" id="1" value="20" />
+    <ctl name="Voip Mode Config" value="12" />
+    <ctl name="Voip Rate Config" value="0" />
+    <ctl name="Voip Evrc Min Max Rate Config" id="0" value="1" />
+    <ctl name="Voip Evrc Min Max Rate Config" id="1" value="4" />
+    <ctl name="Voip Dtx Mode" value="0" />
+    <ctl name="TTY Mode" value="OFF" />
+    <ctl name="LINEOUT1 Volume" value="13" />
+    <ctl name="LINEOUT2 Volume" value="13" />
+    <ctl name="LINEOUT3 Volume" value="13" />
+    <ctl name="LINEOUT4 Volume" value="13" />
+    <ctl name="HPHL Volume" value="20" />
+    <ctl name="HPHR Volume" value="20" />
+    <ctl name="RX0 Digital Volume" value="84" />
+    <ctl name="RX1 Digital Volume" value="84" />
+    <ctl name="RX2 Digital Volume" value="84" />
+    <ctl name="RX3 Digital Volume" value="84" />
+    <ctl name="RX4 Digital Volume" value="84" />
+    <ctl name="RX5 Digital Volume" value="84" />
+    <ctl name="RX6 Digital Volume" value="84" />
+    <ctl name="RX7 Digital Volume" value="84" />
+    <ctl name="RX8 Digital Volume" value="84" />
+    <ctl name="RX0 Mix Digital Volume" value="84" />
+    <ctl name="RX1 Mix Digital Volume" value="84" />
+    <ctl name="RX2 Mix Digital Volume" value="84" />
+    <ctl name="RX3 Mix Digital Volume" value="84" />
+    <ctl name="RX4 Mix Digital Volume" value="84" />
+    <ctl name="RX5 Mix Digital Volume" value="84" />
+    <ctl name="RX6 Mix Digital Volume" value="84" />
+    <ctl name="RX7 Mix Digital Volume" value="84" />
+    <ctl name="RX8 Mix Digital Volume" value="84" />
+    <ctl name="ADC1 Volume" value="12" />
+    <ctl name="ADC2 Volume" value="12" />
+    <ctl name="ADC3 Volume" value="0" />
+    <ctl name="ADC4 Volume" value="0" />
+    <ctl name="ADC5 Volume" value="12" />
+    <ctl name="ADC6 Volume" value="12" />
+    <ctl name="DEC0 Volume" value="84" />
+    <ctl name="DEC1 Volume" value="84" />
+    <ctl name="DEC2 Volume" value="84" />
+    <ctl name="DEC3 Volume" value="84" />
+    <ctl name="DEC4 Volume" value="84" />
+    <ctl name="DEC5 Volume" value="84" />
+    <ctl name="DEC6 Volume" value="84" />
+    <ctl name="DEC7 Volume" value="84" />
+    <ctl name="DEC8 Volume" value="84" />
+    <ctl name="COMP1 Switch" value="0" />
+    <ctl name="COMP2 Switch" value="0" />
+    <ctl name="COMP7 Switch" value="1" />
+    <ctl name="COMP8 Switch" value="1" />
+    <ctl name="RX HPH Mode" value="CLS_H_HIFI" />
+    <ctl name="SLIMBUS_3_RX Port Mixer MI2S_TX" value="0" />
+    <ctl name="HDMI_RX Port Mixer MI2S_TX" value="0" />
+    <ctl name="SLIMBUS_0_RX Port Mixer SLIM_0_TX" value="0" />
+    <ctl name="AUX_PCM_RX Audio Mixer MultiMedia1" value="0" />
+    <ctl name="AUX_PCM_RX Audio Mixer MultiMedia4" value="0" />
+    <ctl name="AUX_PCM_RX Audio Mixer MultiMedia5" value="0" />
+    <ctl name="AUX_PCM_RX Audio Mixer MultiMedia7" value="0" />
+    <ctl name="AUX_PCM_RX Audio Mixer MultiMedia10" value="0" />
+    <ctl name="AUX_PCM_RX Audio Mixer MultiMedia11" value="0" />
+    <ctl name="AUX_PCM_RX Audio Mixer MultiMedia12" value="0" />
+    <ctl name="AUX_PCM_RX Audio Mixer MultiMedia13" value="0" />
+    <ctl name="AUX_PCM_RX Audio Mixer MultiMedia14" value="0" />
+    <ctl name="AUX_PCM_RX Audio Mixer MultiMedia15" value="0" />
+    <ctl name="AUX_PCM_RX Audio Mixer MultiMedia16" value="0" />
+    <ctl name="SLIMBUS_4_RX Audio Mixer MultiMedia1" value="0" />
+    <ctl name="SLIMBUS_4_RX Audio Mixer MultiMedia2" value="0" />
+    <ctl name="MultiMedia5 Mixer SLIM_0_TX" value="0" />
+    <ctl name="MultiMedia5 Mixer AFE_PCM_TX" value="0" />
+    <ctl name="MultiMedia4 Mixer MI2S_TX" value="0" />
+    <ctl name="MultiMedia1 Mixer MI2S_TX" value="0" />
+    <ctl name="MultiMedia7 Mixer MI2S_TX" value="0" />
+    <ctl name="MultiMedia10 Mixer MI2S_TX" value="0" />
+    <ctl name="MultiMedia11 Mixer MI2S_TX" value="0" />
+    <ctl name="MultiMedia12 Mixer MI2S_TX" value="0" />
+    <ctl name="MultiMedia13 Mixer MI2S_TX" value="0" />
+    <ctl name="MultiMedia14 Mixer MI2S_TX" value="0" />
+    <ctl name="MultiMedia15 Mixer MI2S_TX" value="0" />
+    <ctl name="MultiMedia16 Mixer MI2S_TX" value="0" />
+    <ctl name="MultiMedia1 Mixer SLIM_0_TX" value="0" />
+    <ctl name="MultiMedia1 Mixer SLIM_4_TX" value="0" />
+    <ctl name="MultiMedia1 Mixer AUX_PCM_TX" value="0" />
+    <ctl name="MultiMedia1 Mixer AUX_PCM_UL_TX" value="0" />
+    <ctl name="MI2S_HDMI_RX Audio Mixer MultiMedia1" value="0" />
+    <ctl name="MI2S_HDMI_RX Audio Mixer MultiMedia2" value="0" />
+    <ctl name="MI2S_HDMI_RX Audio Mixer MultiMedia3" value="0" />
+    <ctl name="MI2S_HDMI_RX Audio Mixer MultiMedia4" value="0" />
+    <ctl name="MI2S_HDMI_RX Audio Mixer MultiMedia5" value="0" />
+    <ctl name="MI2S_HDMI_RX Audio Mixer MultiMedia7" value="0" />
+    <ctl name="MI2S_HDMI_RX Audio Mixer MultiMedia10" value="0" />
+    <ctl name="MI2S_HDMI_RX Audio Mixer MultiMedia11" value="0" />
+    <ctl name="MI2S_HDMI_RX Audio Mixer MultiMedia12" value="0" />
+    <ctl name="MI2S_HDMI_RX Audio Mixer MultiMedia13" value="0" />
+    <ctl name="MI2S_HDMI_RX Audio Mixer MultiMedia14" value="0" />
+    <ctl name="MI2S_HDMI_RX Audio Mixer MultiMedia15" value="0" />
+    <ctl name="MI2S_HDMI_RX Audio Mixer MultiMedia16" value="0" />
+    <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia1" value="0" />
+    <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia2" value="0" />
+    <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia3" value="0" />
+    <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia4" value="0" />
+    <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia5" value="0" />
+    <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia7" value="0" />
+    <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia10" value="0" />
+    <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia11" value="0" />
+    <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia12" value="0" />
+    <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia13" value="0" />
+    <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia14" value="0" />
+    <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia15" value="0" />
+    <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia16" value="0" />
+    <ctl name="MultiMedia6 Mixer SLIM_0_TX" value="0" />
+    <ctl name="IIR0 INP0 MUX" value="ZERO" />
+    <ctl name="IIR0 INP1 MUX" value="ZERO" />
+    <ctl name="IIR0 INP2 MUX" value="ZERO" />
+    <ctl name="IIR1 INP0 MUX" value="ZERO" />
+    <ctl name="IIR1 INP1 MUX" value="ZERO" />
+    <ctl name="IIR1 INP2 MUX" value="ZERO" />
+    <ctl name="SLIM0_RX_VI_FB_LCH_MUX" value="ZERO" />
+    <ctl name="SLIM0_RX_VI_FB_RCH_MUX" value="ZERO" />
+    <ctl name="VI_FEED_TX Channels" value="Two" />
+    <ctl name="AIF4_VI Mixer SPKR_VI_1" value="0" />
+    <ctl name="AIF4_VI Mixer SPKR_VI_2" value="0" />
+    <ctl name="SLIM TX13 MUX" value="ZERO" />
+    <ctl name="SLIM TX10 MUX" value="ZERO" />
+    <ctl name="SLIM TX9 MUX" value="ZERO" />
+    <ctl name="SLIM TX8 MUX" value="ZERO" />
+    <ctl name="SLIM TX7 MUX" value="ZERO" />
+    <ctl name="SLIM TX6 MUX" value="ZERO" />
+    <ctl name="SLIM TX5 MUX" value="ZERO" />
+    <ctl name="SLIM TX4 MUX" value="ZERO" />
+    <ctl name="SLIM TX3 MUX" value="ZERO" />
+    <ctl name="SLIM TX2 MUX" value="ZERO" />
+    <ctl name="SLIM TX1 MUX" value="ZERO" />
+    <ctl name="SLIM TX0 MUX" value="ZERO" />
+    <ctl name="ADC MUX13" value="AMIC" />
+    <ctl name="ADC MUX12" value="AMIC" />
+    <ctl name="ADC MUX11" value="AMIC" />
+    <ctl name="ADC MUX10" value="AMIC" />
+    <ctl name="ADC MUX8" value="AMIC" />
+    <ctl name="ADC MUX7" value="AMIC" />
+    <ctl name="ADC MUX6" value="AMIC" />
+    <ctl name="ADC MUX5" value="AMIC" />
+    <ctl name="ADC MUX4" value="AMIC" />
+    <ctl name="ADC MUX3" value="AMIC" />
+    <ctl name="ADC MUX2" value="AMIC" />
+    <ctl name="ADC MUX1" value="AMIC" />
+    <ctl name="ADC MUX0" value="AMIC" />
+    <ctl name="DMIC MUX0" value="ZERO" />
+    <ctl name="DMIC MUX1" value="ZERO" />
+    <ctl name="DMIC MUX2" value="ZERO" />
+    <ctl name="DMIC MUX3" value="ZERO" />
+    <ctl name="DMIC MUX4" value="ZERO" />
+    <ctl name="DMIC MUX5" value="ZERO" />
+    <ctl name="DMIC MUX6" value="ZERO" />
+    <ctl name="DMIC MUX7" value="ZERO" />
+    <ctl name="DMIC MUX8" value="ZERO" />
+    <ctl name="DMIC MUX10" value="ZERO" />
+    <ctl name="DMIC MUX11" value="ZERO" />
+    <ctl name="DMIC MUX12" value="ZERO" />
+    <ctl name="DMIC MUX13" value="ZERO" />
+    <ctl name="AMIC MUX0" value="ZERO" />
+    <ctl name="AMIC MUX1" value="ZERO" />
+    <ctl name="AMIC MUX2" value="ZERO" />
+    <ctl name="AMIC MUX3" value="ZERO" />
+    <ctl name="AMIC MUX4" value="ZERO" />
+    <ctl name="AMIC MUX5" value="ZERO" />
+    <ctl name="AMIC MUX6" value="ZERO" />
+    <ctl name="AMIC MUX7" value="ZERO" />
+    <ctl name="AMIC MUX8" value="ZERO" />
+    <ctl name="AMIC MUX10" value="ZERO" />
+    <ctl name="AMIC MUX11" value="ZERO" />
+    <ctl name="AMIC MUX12" value="ZERO" />
+    <ctl name="AMIC MUX13" value="ZERO" />
+    <ctl name="RX INT0_1 MIX1 INP0" value="ZERO" />
+    <ctl name="RX INT1_1 MIX1 INP0" value="ZERO" />
+    <ctl name="RX INT2_1 MIX1 INP0" value="ZERO" />
+    <ctl name="RX INT3_1 MIX1 INP0" value="ZERO" />
+    <ctl name="RX INT4_1 MIX1 INP0" value="ZERO" />
+    <ctl name="RX INT5_1 MIX1 INP0" value="ZERO" />
+    <ctl name="RX INT6_1 MIX1 INP0" value="ZERO" />
+    <ctl name="RX INT7_1 MIX1 INP0" value="ZERO" />
+    <ctl name="RX INT8_1 MIX1 INP0" value="ZERO" />
+    <ctl name="RX INT0_1 MIX1 INP1" value="ZERO" />
+    <ctl name="RX INT1_1 MIX1 INP1" value="ZERO" />
+    <ctl name="RX INT2_1 MIX1 INP1" value="ZERO" />
+    <ctl name="RX INT3_1 MIX1 INP1" value="ZERO" />
+    <ctl name="RX INT4_1 MIX1 INP1" value="ZERO" />
+    <ctl name="RX INT5_1 MIX1 INP1" value="ZERO" />
+    <ctl name="RX INT6_1 MIX1 INP1" value="ZERO" />
+    <ctl name="RX INT7_1 MIX1 INP1" value="ZERO" />
+    <ctl name="RX INT8_1 MIX1 INP1" value="ZERO" />
+    <ctl name="RX INT0_1 MIX1 INP2" value="ZERO" />
+    <ctl name="RX INT1_1 MIX1 INP2" value="ZERO" />
+    <ctl name="RX INT2_1 MIX1 INP2" value="ZERO" />
+    <ctl name="RX INT3_1 MIX1 INP2" value="ZERO" />
+    <ctl name="RX INT4_1 MIX1 INP2" value="ZERO" />
+    <ctl name="RX INT5_1 MIX1 INP2" value="ZERO" />
+    <ctl name="RX INT6_1 MIX1 INP2" value="ZERO" />
+    <ctl name="RX INT7_1 MIX1 INP2" value="ZERO" />
+    <ctl name="RX INT8_1 MIX1 INP2" value="ZERO" />
+    <ctl name="RX INT0_2 MUX" value="ZERO" />
+    <ctl name="RX INT1_2 MUX" value="ZERO" />
+    <ctl name="RX INT2_2 MUX" value="ZERO" />
+    <ctl name="RX INT3_2 MUX" value="ZERO" />
+    <ctl name="RX INT4_2 MUX" value="ZERO" />
+    <ctl name="RX INT5_2 MUX" value="ZERO" />
+    <ctl name="RX INT6_2 MUX" value="ZERO" />
+    <ctl name="RX INT7_2 MUX" value="ZERO" />
+    <ctl name="RX INT8_2 MUX" value="ZERO" />
+    <ctl name="SPL SRC0 MUX" value="ZERO" />
+    <ctl name="SPL SRC1 MUX" value="ZERO" />
+    <ctl name="SPL SRC2 MUX" value="ZERO" />
+    <ctl name="SPL SRC3 MUX" value="ZERO" />
+    <ctl name="RX INT1 SPLINE MIX HPHL Switch" value="0" />
+    <ctl name="RX INT3 SPLINE MIX LO1 Switch" value="0" />
+    <ctl name="RX INT2 SPLINE MIX HPHR Switch" value="0" />
+    <ctl name="RX INT4 SPLINE MIX LO2 Switch" value="0" />
+    <ctl name="RX MIX TX0 MUX" value="ZERO" />
+    <ctl name="RX MIX TX1 MUX" value="ZERO" />
+    <ctl name="RX MIX TX2 MUX" value="ZERO" />
+    <ctl name="RX MIX TX3 MUX" value="ZERO" />
+    <ctl name="RX MIX TX4 MUX" value="ZERO" />
+    <ctl name="RX MIX TX5 MUX" value="ZERO" />
+    <ctl name="RX MIX TX6 MUX" value="ZERO" />
+    <ctl name="RX MIX TX7 MUX" value="ZERO" />
+    <ctl name="RX MIX TX8 MUX" value="ZERO" />
+    <ctl name="IIR0 INP0 MUX" value="ZERO" />
+    <ctl name="IIR0 INP1 MUX" value="ZERO" />
+    <ctl name="IIR0 INP2 MUX" value="ZERO" />
+    <ctl name="IIR0 INP3 MUX" value="ZERO" />
+    <ctl name="IIR1 INP0 MUX" value="ZERO" />
+    <ctl name="IIR1 INP1 MUX" value="ZERO" />
+    <ctl name="IIR1 INP2 MUX" value="ZERO" />
+    <ctl name="IIR1 INP3 MUX" value="ZERO" />
+    <ctl name="RX INT0 DEM MUX" value="CLSH_DSM_OUT" />
+    <ctl name="RX INT1 DEM MUX" value="CLSH_DSM_OUT" />
+    <ctl name="RX INT2 DEM MUX" value="CLSH_DSM_OUT" />
+    <ctl name="SLIM_0_RX Channels" value="One" />
+    <ctl name="SLIM_0_TX Channels" value="One" />
+    <ctl name="SLIM_1_TX Channels" value="One" />
+    <ctl name="SLIM RX0 MUX" value="ZERO" />
+    <ctl name="SLIM RX3 MUX" value="ZERO" />
+    <ctl name="SLIM RX4 MUX" value="ZERO" />
+    <ctl name="EAR PA Gain" value="G_6_DB" />
+    <ctl name="SpkrLeft COMP Switch" value="0" />
+    <ctl name="SpkrRight COMP Switch" value="0" />
+    <ctl name="SpkrLeft BOOST Switch" value="0" />
+    <ctl name="SpkrRight BOOST Switch" value="0" />
+    <ctl name="SpkrLeft VISENSE Switch" value="0" />
+    <ctl name="SpkrRight VISENSE Switch" value="0" />
+    <ctl name="SpkrLeft SWR DAC_Port Switch" value="0" />
+    <ctl name="SpkrRight SWR DAC_Port Switch" value="0" />
+    <ctl name="SLIM RX1 MUX" value="ZERO" />
+    <ctl name="AIF1_CAP Mixer SLIM TX7" value="0" />
+    <ctl name="AIF1_CAP Mixer SLIM TX8" value="0"/>
+    <ctl name="AIF1_CAP Mixer SLIM TX6" value="0" />
+    <ctl name="AIF1_CAP Mixer SLIM TX5" value="0"/>
+    <ctl name="AIF1_CAP Mixer SLIM TX4" value="0" />
+    <ctl name="AIF1_CAP Mixer SLIM TX3" value="0"/>
+    <ctl name="AIF1_CAP Mixer SLIM TX2" value="0" />
+    <ctl name="AIF1_CAP Mixer SLIM TX1" value="0"/>
+    <ctl name="AIF1_CAP Mixer SLIM TX0" value="0"/>
+    <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia4" value="0" />
+    <ctl name="HDMI Mixer MultiMedia4" value="0" />
+    <!-- echo reference -->
+    <ctl name="AUDIO_REF_EC_UL1 MUX" value="None" />
+    <!-- usb headset -->
+    <ctl name="AFE_PCM_RX Audio Mixer MultiMedia1" value="0" />
+    <ctl name="AFE_PCM_RX Audio Mixer MultiMedia3" value="0" />
+    <ctl name="AFE_PCM_RX Audio Mixer MultiMedia4" value="0" />
+    <ctl name="AFE_PCM_RX Audio Mixer MultiMedia7" value="0" />
+    <ctl name="AFE_PCM_RX Audio Mixer MultiMedia10" value="0" />
+    <ctl name="AFE_PCM_RX Audio Mixer MultiMedia11" value="0" />
+    <ctl name="AFE_PCM_RX Audio Mixer MultiMedia12" value="0" />
+    <ctl name="AFE_PCM_RX Audio Mixer MultiMedia13" value="0" />
+    <ctl name="AFE_PCM_RX Audio Mixer MultiMedia14" value="0" />
+    <ctl name="AFE_PCM_RX Audio Mixer MultiMedia15" value="0" />
+    <ctl name="AFE_PCM_RX Audio Mixer MultiMedia16" value="0" />
+    <ctl name="MultiMedia1 Mixer AFE_PCM_TX" value="0" />
+    <ctl name="AFE_PCM_RX Audio Mixer MultiMedia5" value="0" />
+    <!-- usb headset end -->
+    <!-- fm -->
+    <ctl name="SLIMBUS_0_RX Port Mixer QUIN_MI2S_TX" value="0" />
+    <ctl name="SLIMBUS_DL_HL Switch" value="0" />
+    <ctl name="MultiMedia1 Mixer QUIN_MI2S_TX" value="0" />
+    <ctl name="MultiMedia2 Mixer QUIN_MI2S_TX" value="0" />
+    <ctl name="INTERNAL_FM_RX Audio Mixer MultiMedia1" value="0" />
+    <ctl name="INTERNAL_FM_RX Audio Mixer MultiMedia5" value="0" />
+    <ctl name="INTERNAL_FM_RX Audio Mixer MultiMedia4" value="0" />
+<!-- fm end -->
+    <!-- RT Proxy Cal -->
+    <ctl name="RT_PROXY_1_RX SetCalMode" value="CAL_MODE_NONE" />
+    <ctl name="RT_PROXY_1_TX SetCalMode" value="CAL_MODE_NONE" />
+    <!-- RT Proxy Cal end -->
+    <!-- Voice -->
+    <ctl name="SLIM_0_RX_Voice Mixer CSVoice" value="0" />
+    <ctl name="Voice_Tx Mixer SLIM_0_TX_Voice" value="0" />
+    <!-- Voice HDMI -->
+    <ctl name="HDMI_RX_Voice Mixer CSVoice" value="0" />
+    <!-- Voice BTSCO -->
+    <ctl name="AUX PCM SampleRate" value="8000" />
+    <ctl name="AUX_PCM_RX_Voice Mixer CSVoice" value="0" />
+    <ctl name="Voice_Tx Mixer AUX_PCM_TX_Voice" value="0" />
+    <!-- Voice USB headset -->
+    <ctl name="AFE_PCM_RX_Voice Mixer CSVoice" value="0" />
+    <ctl name="Voice_Tx Mixer AFE_PCM_TX_Voice" value="0" />
+    <!-- Voice end-->
+
+    <!-- Voice2 -->
+    <ctl name="SLIM_0_RX_Voice Mixer Voice2" value="0" />
+    <ctl name="Voice2_Tx Mixer SLIM_0_TX_Voice2" value="0" />
+    <!-- Voice2 HDMI -->
+    <ctl name="HDMI_RX_Voice Mixer Voice2" value="0" />
+    <!-- Voice2 BTSCO -->
+    <ctl name="AUX_PCM_RX_Voice Mixer Voice2" value="0" />
+    <ctl name="Voice2_Tx Mixer AUX_PCM_TX_Voice2" value="0" />
+    <!-- Voice2 USB headset -->
+    <ctl name="AFE_PCM_RX_Voice Mixer Voice2" value="0" />
+    <ctl name="Voice2_Tx Mixer AFE_PCM_TX_Voice2" value="0" />
+    <!-- Voice2 end-->
+
+    <!-- VoLTE -->
+    <ctl name="SLIM_0_RX_Voice Mixer VoLTE" value="0" />
+    <ctl name="VoLTE_Tx Mixer SLIM_0_TX_VoLTE" value="0" />
+    <!-- VoLTE HDMI -->
+    <ctl name="HDMI_RX_Voice Mixer VoLTE" value="0" />
+    <!-- VoLTE BTSCO -->
+    <ctl name="AUX_PCM_RX_Voice Mixer VoLTE" value="0" />
+    <ctl name="VoLTE_Tx Mixer AUX_PCM_TX_VoLTE" value="0" />
+    <!-- VoLTE USB headset -->
+    <ctl name="AFE_PCM_RX_Voice Mixer VoLTE" value="0" />
+    <ctl name="VoLTE_Tx Mixer AFE_PCM_TX_VoLTE" value="0" />
+    <!-- VoLTE end-->
+
+    <!-- Multimode Voice1 -->
+    <ctl name="SLIM_0_RX_Voice Mixer VoiceMMode1" value="0" />
+    <ctl name="VoiceMMode1_Tx Mixer SLIM_0_TX_MMode1" value="0" />
+    <!-- Multimode Voice1 HDMI -->
+    <ctl name="HDMI_RX_Voice Mixer VoiceMMode1" value="0" />
+    <!-- Multimode Voice1 BTSCO -->
+    <ctl name="AUX_PCM_RX_Voice Mixer VoiceMMode1" value="0" />
+    <ctl name="VoiceMMode1_Tx Mixer AUX_PCM_TX_MMode1" value="0" />
+    <!-- Multimode Voice1 USB headset -->
+    <ctl name="AFE_PCM_RX_Voice Mixer VoiceMMode1" value="0" />
+    <ctl name="VoiceMMode1_Tx Mixer AFE_PCM_TX_MMode1" value="0" />
+    <!-- Miltimode Voice1 end-->
+
+    <!-- Multimode Voice2 -->
+    <ctl name="SLIM_0_RX_Voice Mixer VoiceMMode2" value="0" />
+    <ctl name="VoiceMMode2_Tx Mixer SLIM_0_TX_MMode2" value="0" />
+    <!-- Multimode Voice2 HDMI -->
+    <ctl name="HDMI_RX_Voice Mixer VoiceMMode2" value="0" />
+    <!-- Multimode Voice2 BTSCO -->
+    <ctl name="AUX_PCM_RX_Voice Mixer VoiceMMode2" value="0" />
+    <ctl name="VoiceMMode2_Tx Mixer AUX_PCM_TX_MMode2" value="0" />
+    <!-- Multimode Voice2 USB headset -->
+    <ctl name="AFE_PCM_RX_Voice Mixer VoiceMMode2" value="0" />
+    <ctl name="VoiceMMode2_Tx Mixer AFE_PCM_TX_MMode2" value="0" />
+    <!-- Multimode Voice2 end-->
+
+    <!-- Voice external ec. reference -->
+    <ctl name="VOC_EXT_EC MUX" value="NONE" />
+    <ctl name="AIF3_CAP Mixer SLIM TX1" value="0" />
+    <ctl name="AIF3_CAP Mixer SLIM TX2" value="0" />
+    <!-- Voice external ec. reference end -->
+
+    <!-- Incall Recording -->
+    <ctl name="MultiMedia1 Mixer VOC_REC_UL" value="0" />
+    <ctl name="MultiMedia1 Mixer VOC_REC_DL" value="0" />
+    <ctl name="MultiMedia8 Mixer VOC_REC_UL" value="0" />
+    <ctl name="MultiMedia8 Mixer VOC_REC_DL" value="0" />
+    <!-- Incall Recording End -->
+
+    <!-- Incall Music -->
+    <ctl name="Incall_Music Audio Mixer MultiMedia2" value="0" />
+    <ctl name="Incall_Music_2 Audio Mixer MultiMedia9" value="0" />
+    <!-- Incall Music End -->
+
+    <!-- compress-voip-call start -->
+    <ctl name="SLIM_0_RX_Voice Mixer Voip" value="0" />
+    <ctl name="Voip_Tx Mixer SLIM_0_TX_Voip" value="0" />
+    <ctl name="AUX_PCM_RX_Voice Mixer Voip" value="0" />
+    <ctl name="Voip_Tx Mixer AUX_PCM_TX_Voip" value="0" />
+    <ctl name="AFE_PCM_RX_Voice Mixer Voip" value="0" />
+    <ctl name="Voip_Tx Mixer AFE_PCM_TX_Voip" value="0" />
+    <!-- compress-voip-call end-->
+
+    <!-- QCHAT start -->
+    <ctl name="SLIM_0_RX_Voice Mixer QCHAT" value="0" />
+    <ctl name="QCHAT_Tx Mixer SLIM_0_TX_QCHAT" value="0" />
+    <ctl name="AUX_PCM_RX_Voice Mixer QCHAT" value="0" />
+    <ctl name="QCHAT_Tx Mixer AUX_PCM_TX_QCHAT" value="0" />
+    <!-- QCHAT end-->
+
+    <!-- VoWLAN start -->
+    <ctl name="SLIM_0_RX_Voice Mixer VoWLAN" value="0" />
+    <ctl name="VoWLAN_Tx Mixer SLIM_0_TX_VoWLAN" value="0" />
+    <ctl name="HDMI_RX_Voice Mixer VoWLAN" value="0" />
+    <ctl name="AUX_PCM_RX_Voice Mixer VoWLAN" value="0" />
+    <ctl name="VoWLAN_Tx Mixer AUX_PCM_TX_VoWLAN" value="0" />
+    <ctl name="AFE_PCM_RX_Voice Mixer VoWLAN" value="0" />
+    <ctl name="VoWLAN_Tx Mixer AFE_PCM_TX_VoWLAN" value="0" />
+    <!-- VoWLAN end-->
+
+    <!-- Audio BTSCO -->
+    <ctl name="AUX_PCM_RX Audio Mixer MultiMedia1" value="0" />
+    <ctl name="AUX_PCM_RX Audio Mixer MultiMedia3" value="0" />
+    <ctl name="AUX_PCM_RX Audio Mixer MultiMedia4" value="0" />
+    <ctl name="AUX_PCM_RX Audio Mixer MultiMedia5" value="0" />
+    <ctl name="AUX_PCM_RX Audio Mixer MultiMedia6" value="0" />
+    <ctl name="MultiMedia1 Mixer AUX_PCM_TX" value="0" />
+    <ctl name="MultiMedia5 Mixer AUX_PCM_TX" value="0" />
+
+    <!-- IIR/voice anc -->
+    <ctl name="IIR0 Band1" id ="0" value="268435456" />
+    <ctl name="IIR0 Band1" id ="1" value="0" />
+    <ctl name="IIR0 Band1" id ="2" value="0" />
+    <ctl name="IIR0 Band1" id ="3" value="0" />
+    <ctl name="IIR0 Band1" id ="4" value="0" />
+    <ctl name="IIR0 Band2" id ="0" value="268435456" />
+    <ctl name="IIR0 Band2" id ="1" value="0" />
+    <ctl name="IIR0 Band2" id ="2" value="0" />
+    <ctl name="IIR0 Band2" id ="3" value="0" />
+    <ctl name="IIR0 Band2" id ="4" value="0" />
+    <ctl name="IIR0 Band3" id ="0" value="268435456" />
+    <ctl name="IIR0 Band3" id ="1" value="0" />
+    <ctl name="IIR0 Band3" id ="2" value="0" />
+    <ctl name="IIR0 Band3" id ="3" value="0" />
+    <ctl name="IIR0 Band3" id ="4" value="0" />
+    <ctl name="IIR0 Band4" id ="0" value="268435456" />
+    <ctl name="IIR0 Band4" id ="1" value="0" />
+    <ctl name="IIR0 Band4" id ="2" value="0" />
+    <ctl name="IIR0 Band4" id ="3" value="0" />
+    <ctl name="IIR0 Band4" id ="4" value="0" />
+    <ctl name="IIR0 Band5" id ="0" value="268435456" />
+    <ctl name="IIR0 Band5" id ="1" value="0" />
+    <ctl name="IIR0 Band5" id ="2" value="0" />
+    <ctl name="IIR0 Band5" id ="3" value="0" />
+    <ctl name="IIR0 Band5" id ="4" value="0" />
+    <ctl name="IIR0 Enable Band1" value="0" />
+    <ctl name="IIR0 Enable Band2" value="0" />
+    <ctl name="IIR0 Enable Band3" value="0" />
+    <ctl name="IIR0 Enable Band4" value="0" />
+    <ctl name="IIR0 Enable Band5" value="0" />
+    <ctl name="IIR0 INP0 Volume" value="54" />
+    <ctl name="IIR0 INP1 Volume" value="54" />
+    <ctl name="IIR1 Band1" id ="0" value="268435456" />
+    <ctl name="IIR1 Band1" id ="1" value="0" />
+    <ctl name="IIR1 Band1" id ="2" value="0" />
+    <ctl name="IIR1 Band1" id ="3" value="0" />
+    <ctl name="IIR1 Band1" id ="4" value="0" />
+    <ctl name="IIR1 Band2" id ="0" value="268435456" />
+    <ctl name="IIR1 Band2" id ="1" value="0" />
+    <ctl name="IIR1 Band2" id ="2" value="0" />
+    <ctl name="IIR1 Band2" id ="3" value="0" />
+    <ctl name="IIR1 Band2" id ="4" value="0" />
+    <ctl name="IIR1 Band3" id ="0" value="268435456" />
+    <ctl name="IIR1 Band3" id ="1" value="0" />
+    <ctl name="IIR1 Band3" id ="2" value="0" />
+    <ctl name="IIR1 Band3" id ="3" value="0" />
+    <ctl name="IIR1 Band3" id ="4" value="0" />
+    <ctl name="IIR1 Band4" id ="0" value="268435456" />
+    <ctl name="IIR1 Band4" id ="1" value="0" />
+    <ctl name="IIR1 Band4" id ="2" value="0" />
+    <ctl name="IIR1 Band4" id ="3" value="0" />
+    <ctl name="IIR1 Band4" id ="4" value="0" />
+    <ctl name="IIR1 Band5" id ="0" value="268435456" />
+    <ctl name="IIR1 Band5" id ="1" value="0" />
+    <ctl name="IIR1 Band5" id ="2" value="0" />
+    <ctl name="IIR1 Band5" id ="3" value="0" />
+    <ctl name="IIR1 Band5" id ="4" value="0" />
+    <ctl name="IIR1 Enable Band1" value="0" />
+    <ctl name="IIR1 Enable Band2" value="0" />
+    <ctl name="IIR1 Enable Band3" value="0" />
+    <ctl name="IIR1 Enable Band4" value="0" />
+    <ctl name="IIR1 Enable Band5" value="0" />
+    <ctl name="IIR1 INP0 Volume" value="54" />
+    <!-- IIR/voice anc end -->
+    <!-- anc handset -->
+    <ctl name="ANC Slot" value="0" />
+    <ctl name="ANC0 FB MUX" value="ZERO" />
+    <ctl name="ANC1 FB MUX" value="ZERO" />
+    <ctl name="ANC EAR Enable Switch" value="0" />
+    <!-- anc handset end -->
+    <ctl name="ANC Function" value="OFF" />
+    <ctl name="ANC HPHL Enable Switch" value="0" />
+    <ctl name="ANC HPHR Enable Switch" value="0" />
+    <!-- anc headset end-->
+    <!-- aanc handset mic -->
+    <ctl name="AIF1_CAP Mixer SLIM TX9" value="0" />
+    <ctl name="AANC_SLIM_0_RX MUX" value="ZERO" />
+    <!-- aanc handset mic end -->
+    <!-- ssr qmic -->
+    <ctl name="AIF1_CAP Mixer SLIM TX10" value="0" />
+    <!-- ssr qmic end-->
+    <!-- vbat related data -->
+    <ctl name="GSM mode Enable" value="OFF" />
+    <ctl name="RX INT5 VBAT LO3 VBAT Enable" value="0" />
+    <ctl name="RX INT6 VBAT LO4 VBAT Enable" value="0" />
+    <ctl name="RX INT7 VBAT SPKRL VBAT Enable" value="0" />
+    <ctl name="RX INT8 VBAT SPKRR VBAT Enable" value="0" />
+    <!-- vbat related data end-->
+    <!-- audio record compress-->
+    <ctl name="MultiMedia8 Mixer SLIM_0_TX" value="0" />
+    <ctl name="MultiMedia8 Mixer AUX_PCM_TX" value="0" />
+    <ctl name="MultiMedia8 Mixer AFE_PCM_TX" value="0" />
+    <!-- audio record compress end-->
+    <!-- listen -->
+    <ctl name="LSM1 MUX" value="None" />
+    <ctl name="LSM2 MUX" value="None" />
+    <ctl name="LSM3 MUX" value="None" />
+    <ctl name="LSM4 MUX" value="None" />
+    <ctl name="LSM5 MUX" value="None" />
+    <ctl name="LSM6 MUX" value="None" />
+    <ctl name="LSM7 MUX" value="None" />
+    <ctl name="LSM8 MUX" value="None" />
+    <ctl name="SLIMBUS_5_TX LSM Function" value="None" />
+    <!-- listen end-->
+    <!-- afe-proxy -->
+    <ctl name="AFE_PCM_RX Audio Mixer MultiMedia2" value="0" />
+    <!-- afe-proxy end-->
+
+    <!-- ADSP testfwk -->
+    <ctl name="SLIMBUS_DL_HL Switch" value="0" />
+    <!-- ADSP testfwk end-->
+
+    <ctl name="MSM_Ear_Enable_States" value="Disable"/>
+
+    <!-- Speaker Reverse -->
+    <ctl name="Set Custom Stereo OnOff" value="0" />
+    <!-- Speaker Reverse end -->
+
+    <!-- Speaker reverse, mono -->
+    <ctl name="Set Custom Stereo" value="Off" />
+    <!-- Speaker reverse, mono end -->
+
+    <!-- Stereo Rec -->
+    <ctl name="SLIM_0_TX Format" value="S16_LE" />
+    <!-- Stereo Rec end -->
+
+    <!-- Rx HPF -->
+    <ctl name="RX INT1_1 HPF cut off" value="CF_NEG_3DB_0P48HZ" />
+    <ctl name="RX INT2_1 HPF cut off" value="CF_NEG_3DB_0P48HZ" />
+    <!-- Rx HPF end -->
+
+    <!-- These are audio route (FE to BE) specific mixer settings -->
+    <path name="deep-buffer-playback">
+        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia1" value="1" />
+    </path>
+
+    <path name="deep-buffer-playback speaker-protected">
+        <path name="deep-buffer-playback" />
+    </path>
+
+    <ctl name="LDO_H Enable" value="0"/>
+
+    <path name="gsm-mode">
+        <ctl name="GSM mode Enable" value="ON" />
+    </path>
+
+    <path name="vbat-speaker-mono echo-reference">
+        <ctl name="VOC_EXT_EC MUX" value="SLIM_1_TX" />
+        <ctl name="AIF3_CAP Mixer SLIM TX1" value="1" />
+        <ctl name="SLIM TX1 MUX" value="RX_MIX_TX1" />
+        <ctl name="RX MIX TX1 MUX" value="RX_MIX_VBAT7" />
+        <ctl name="SLIM_1_TX Channels" value="One" />
+   </path>
+
+   <path name="vbat-speaker echo-reference">
+        <ctl name="AUDIO_REF_EC_UL1 MUX" value="SLIM_1_TX" />
+        <ctl name="AIF3_CAP Mixer SLIM TX1" value="1" />
+        <ctl name="AIF3_CAP Mixer SLIM TX2" value="1" />
+        <ctl name="SLIM TX1 MUX" value="RX_MIX_TX1" />
+        <ctl name="SLIM TX2 MUX" value="RX_MIX_TX2" />
+        <ctl name="RX MIX TX1 MUX" value="RX_MIX_VBAT7" />
+        <ctl name="RX MIX TX2 MUX" value="RX_MIX_VBAT8" />
+        <ctl name="SLIM_1_TX Channels" value="Two" />
+    </path>
+
+    <path name="echo-reference">
+        <ctl name="AUDIO_REF_EC_UL1 MUX" value="SLIM_RX" />
+    </path>
+
+    <path name="deep-buffer-playback hdmi">
+        <ctl name="MI2S_HDMI_RX Audio Mixer MultiMedia1" value="1" />
+    </path>
+
+    <path name="deep-buffer-playback speaker-and-hdmi">
+        <path name="deep-buffer-playback hdmi" />
+        <path name="deep-buffer-playback" />
+    </path>
+
+    <path name="deep-buffer-playback bt-sco">
+        <ctl name="AUX_PCM_RX Audio Mixer MultiMedia1" value="1" />
+    </path>
+
+    <path name="deep-buffer-playback bt-sco-wb">
+        <ctl name="AUX PCM SampleRate" value="16000" />
+        <path name="deep-buffer-playback bt-sco" />
+    </path>
+
+    <path name="deep-buffer-playback afe-proxy">
+        <ctl name="AFE_PCM_RX Audio Mixer MultiMedia1" value="1" />
+    </path>
+
+    <path name="deep-buffer-playback usb-headphones">
+        <path name="deep-buffer-playback afe-proxy" />
+    </path>
+
+    <path name="deep-buffer-playback speaker-and-usb-headphones">
+        <path name="deep-buffer-playback usb-headphones" />
+        <path name="deep-buffer-playback" />
+    </path>
+
+    <path name="deep-buffer-playback transmission-fm">
+        <ctl name="INTERNAL_FM_RX Audio Mixer MultiMedia1" value="1" />
+    </path>
+
+    <path name="deep-buffer-playback headphones">
+        <path name="deep-buffer-playback" />
+    </path>
+
+    <path name="deep-buffer-playback incall-music">
+    </path>
+
+    <path name="deep-buffer-playback incall-music-bt">
+        <path name="deep-buffer-playback incall-music" />
+    </path>
+
+    <path name="deep-buffer-playback incall-music-bt-wb">
+        <ctl name="AUX PCM SampleRate" value="16000" />
+        <path name="deep-buffer-playback incall-music" />
+    </path>
+
+    <path name="deep-buffer-playback incall-music2">
+    </path>
+
+    <path name="deep-buffer-playback incall-music2-bt">
+        <path name="deep-buffer-playback incall-music2" />
+    </path>
+
+    <path name="deep-buffer-playback incall-music2-bt-wb">
+        <ctl name="AUX PCM SampleRate" value="16000" />
+        <path name="deep-buffer-playback incall-music2" />
+    </path>
+
+    <path name="low-latency-playback">
+        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia5" value="1" />
+    </path>
+
+    <path name="low-latency-playback speaker-protected">
+        <path name="low-latency-playback" />
+    </path>
+
+    <path name="low-latency-playback hdmi">
+        <ctl name="MI2S_HDMI_RX Audio Mixer MultiMedia5" value="1" />
+    </path>
+
+    <path name="low-latency-playback bt-sco">
+        <ctl name="AUX_PCM_RX Audio Mixer MultiMedia5" value="1" />
+    </path>
+
+    <path name="low-latency-playback bt-sco-wb">
+        <ctl name="AUX PCM SampleRate" value="16000" />
+        <path name="low-latency-playback bt-sco" />
+    </path>
+
+    <path name="low-latency-playback speaker-and-hdmi">
+        <path name="low-latency-playback hdmi" />
+        <path name="low-latency-playback" />
+    </path>
+
+    <path name="low-latency-playback afe-proxy">
+        <ctl name="AFE_PCM_RX Audio Mixer MultiMedia5" value="1" />
+    </path>
+
+    <path name="low-latency-playback usb-headphones">
+        <path name="low-latency-playback afe-proxy" />
+    </path>
+
+    <path name="low-latency-playback speaker-and-usb-headphones">
+        <path name="low-latency-playback usb-headphones" />
+        <path name="low-latency-playback" />
+    </path>
+
+    <path name="low-latency-playback transmission-fm">
+        <ctl name="INTERNAL_FM_RX Audio Mixer MultiMedia5" value="1" />
+    </path>
+
+    <path name="low-latency-record capture-fm">
+      <ctl name="MultiMedia5 Mixer QUIN_MI2S_TX" value="1" />
+    </path>
+
+    <path name="low-latency-playback headphones">
+        <path name="low-latency-playback" />
+    </path>
+
+    <path name="audio-ull-playback">
+        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia3" value="1" />
+    </path>
+
+    <path name="audio-ull-playback headphones">
+      <path name="audio-ull-playback" />
+    </path>
+
+    <path name="audio-ull-playback speaker-protected">
+        <path name="audio-ull-playback" />
+    </path>
+
+    <path name="audio-ull-playback bt-sco">
+        <ctl name="AUX_PCM_RX Audio Mixer MultiMedia3" value="1" />
+    </path>
+
+    <path name="audio-ull-playback bt-sco-wb">
+        <ctl name="AUX PCM SampleRate" value="16000" />
+        <path name="audio-ull-playback bt-sco" />
+    </path>
+
+    <path name="audio-ull-playback afe-proxy">
+        <ctl name="AFE_PCM_RX Audio Mixer MultiMedia3" value="1" />
+    </path>
+
+    <path name="audio-ull-playback usb-headphones">
+        <path name="audio-ull-playback afe-proxy"/>
+    </path>
+
+    <path name="audio-ull-playback speaker-and-usb-headphones">
+        <path name="audio-ull-playback usb-headphones"/>
+        <path name="audio-ull-playback"/>
+    </path>
+
+    <path name="low-latency-playback incall-music">
+        <ctl name="Incall_Music Audio Mixer MultiMedia5" value="1" />
+    </path>
+
+    <path name="low-latency-playback incall-music-bt">
+        <path name="low-latency-playback incall-music" />
+    </path>
+
+    <path name="low-latency-playback incall-music-bt-wb">
+        <ctl name="AUX PCM SampleRate" value="16000" />
+        <path name="low-latency-playback incall-music" />
+    </path>
+
+    <path name="low-latency-playback incall-music2">
+        <ctl name="Incall_Music_2 Audio Mixer MultiMedia5" value="1" />
+    </path>
+
+    <path name="low-latency-playback incall-music2-bt">
+        <path name="low-latency-playback incall-music2" />
+    </path>
+
+    <path name="low-latency-playback incall-music2-bt-wb">
+        <ctl name="AUX PCM SampleRate" value="16000" />
+        <path name="low-latency-playback incall-music2" />
+    </path>
+
+    <path name="multi-channel-playback hdmi">
+        <ctl name="MI2S_HDMI_RX Audio Mixer MultiMedia2" value="1" />
+    </path>
+
+    <path name="multi-channel-playback afe-proxy">
+        <ctl name="AFE_PCM_RX Audio Mixer MultiMedia2" value="1" />
+    </path>
+
+    <path name="compress-offload-playback">
+        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia4" value="1" />
+    </path>
+
+    <path name="compress-offload-playback speaker-protected">
+        <path name="compress-offload-playback" />
+    </path>
+
+    <path name="compress-offload-playback hdmi">
+        <ctl name="MI2S_HDMI_RX Audio Mixer MultiMedia4" value="1" />
+    </path>
+
+    <path name="compress-offload-playback bt-sco">
+        <ctl name="AUX_PCM_RX Audio Mixer MultiMedia4" value="1" />
+    </path>
+
+    <path name="compress-offload-playback bt-sco-wb">
+        <ctl name="AUX PCM SampleRate" value="16000" />
+        <path name="compress-offload-playback bt-sco" />
+    </path>
+
+    <path name="compress-offload-playback speaker-and-hdmi">
+        <path name="compress-offload-playback hdmi" />
+        <path name="compress-offload-playback" />
+    </path>
+
+    <path name="compress-offload-playback afe-proxy">
+        <ctl name="AFE_PCM_RX Audio Mixer MultiMedia4" value="1" />
+    </path>
+
+    <path name="compress-offload-playback usb-headphones">
+        <path name="compress-offload-playback afe-proxy" />
+    </path>
+
+    <path name="compress-offload-playback speaker-and-usb-headphones">
+        <path name="compress-offload-playback usb-headphones" />
+        <path name="compress-offload-playback" />
+    </path>
+
+    <path name="compress-offload-playback headphones">
+        <path name="compress-offload-playback" />
+    </path>
+
+    <path name="compress-offload-playback headphones-44.1">
+        <ctl name="SLIMBUS_5_RX Audio Mixer MultiMedia4" value="1" />
+    </path>
+
+    <path name="compress-offload-playback2">
+        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia7" value="1" />
+    </path>
+
+    <path name="compress-offload-playback2 hdmi">
+        <ctl name="MI2S_HDMI_RX Audio Mixer MultiMedia7" value="1" />
+    </path>
+
+    <path name="compress-offload-playback2 bt-sco">
+        <ctl name="AUX_PCM_RX Audio Mixer MultiMedia7" value="1" />
+    </path>
+
+     <path name="compress-offload-playback transmission-fm">
+        <ctl name="INTERNAL_FM_RX Audio Mixer MultiMedia4" value="1" />
+     </path>
+
+    <path name="compress-offload-playback2 bt-sco-wb">
+        <ctl name="AUX PCM SampleRate" value="16000" />
+        <path name="compress-offload-playback2 bt-sco" />
+    </path>
+
+    <path name="compress-offload-playback2 speaker-and-hdmi">
+        <path name="compress-offload-playback2 hdmi" />
+        <path name="compress-offload-playback2" />
+    </path>
+
+    <path name="compress-offload-playback2 afe-proxy">
+        <ctl name="AFE_PCM_RX Audio Mixer MultiMedia7" value="1" />
+    </path>
+
+    <path name="compress-offload-playback2 usb-headphones">
+        <path name="compress-offload-playback2 afe-proxy" />
+    </path>
+
+    <path name="compress-offload-playback2 speaker-and-usb-headphones">
+        <path name="compress-offload-playback2 usb-headphones" />
+        <path name="compress-offload-playback2" />
+    </path>
+
+    <path name="compress-offload-playback2 headphones">
+        <path name="compress-offload-playback2" />
+    </path>
+
+    <path name="compress-offload-playback2 headphones-44.1">
+        <ctl name="SLIMBUS_5_RX Audio Mixer MultiMedia7" value="1" />
+    </path>
+
+    <path name="compress-offload-playback3">
+        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia10" value="1" />
+    </path>
+
+    <path name="compress-offload-playback3 hdmi">
+        <ctl name="MI2S_HDMI_RX Audio Mixer MultiMedia10" value="1" />
+    </path>
+
+    <path name="compress-offload-playback3 bt-sco">
+        <ctl name="AUX_PCM_RX Audio Mixer MultiMedia10" value="1" />
+    </path>
+
+    <path name="compress-offload-playback3 bt-sco-wb">
+        <ctl name="AUX PCM SampleRate" value="16000" />
+        <path name="compress-offload-playback3 bt-sco" />
+    </path>
+
+    <path name="compress-offload-playback3 speaker-and-hdmi">
+        <path name="compress-offload-playback3 hdmi" />
+        <path name="compress-offload-playback3" />
+    </path>
+
+    <path name="compress-offload-playback3 afe-proxy">
+        <ctl name="AFE_PCM_RX Audio Mixer MultiMedia10" value="1" />
+    </path>
+
+    <path name="compress-offload-playback3 usb-headphones">
+        <path name="compress-offload-playback3 afe-proxy" />
+    </path>
+
+    <path name="compress-offload-playback3 speaker-and-usb-headphones">
+        <path name="compress-offload-playback3 usb-headphones" />
+        <path name="compress-offload-playback3" />
+    </path>
+
+    <path name="compress-offload-playback3 headphones">
+        <path name="compress-offload-playback3" />
+    </path>
+
+    <path name="compress-offload-playback3 headphones-44.1">
+        <ctl name="SLIMBUS_5_RX Audio Mixer MultiMedia10" value="1" />
+    </path>
+
+    <path name="compress-offload-playback4">
+        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia11" value="1" />
+    </path>
+
+    <path name="compress-offload-playback4 hdmi">
+        <ctl name="HDMI Mixer MultiMedia11" value="1" />
+    </path>
+
+    <path name="compress-offload-playback4 bt-sco">
+        <ctl name="AUX_PCM_RX Audio Mixer MultiMedia11" value="1" />
+    </path>
+
+    <path name="compress-offload-playback4 bt-sco-wb">
+        <ctl name="AUX PCM SampleRate" value="16000" />
+        <path name="compress-offload-playback4 bt-sco" />
+    </path>
+
+    <path name="compress-offload-playback4 speaker-and-hdmi">
+        <path name="compress-offload-playback4 hdmi" />
+        <path name="compress-offload-playback4" />
+    </path>
+
+    <path name="compress-offload-playback4 afe-proxy">
+        <ctl name="AFE_PCM_RX Audio Mixer MultiMedia11" value="1" />
+    </path>
+
+    <path name="compress-offload-playback4 usb-headphones">
+        <path name="compress-offload-playback4 afe-proxy" />
+    </path>
+
+    <path name="compress-offload-playback4 speaker-and-usb-headphones">
+        <path name="compress-offload-playback4 usb-headphones" />
+        <path name="compress-offload-playback4" />
+    </path>
+
+    <path name="compress-offload-playback4 headphones">
+        <path name="compress-offload-playback4" />
+    </path>
+
+    <path name="compress-offload-playback4 headphones-44.1">
+        <ctl name="SLIMBUS_5_RX Audio Mixer MultiMedia11" value="1" />
+    </path>
+
+    <path name="compress-offload-playback5">
+        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia12" value="1" />
+    </path>
+
+    <path name="compress-offload-playback5 hdmi">
+        <ctl name="HDMI Mixer MultiMedia12" value="1" />
+    </path>
+
+    <path name="compress-offload-playback5 bt-sco">
+        <ctl name="AUX_PCM_RX Audio Mixer MultiMedia12" value="1" />
+    </path>
+
+    <path name="compress-offload-playback5 bt-sco-wb">
+        <ctl name="AUX PCM SampleRate" value="16000" />
+        <path name="compress-offload-playback5 bt-sco" />
+    </path>
+
+    <path name="compress-offload-playback5 speaker-and-hdmi">
+        <path name="compress-offload-playback5 hdmi" />
+        <path name="compress-offload-playback5" />
+    </path>
+
+    <path name="compress-offload-playback5 afe-proxy">
+        <ctl name="AFE_PCM_RX Audio Mixer MultiMedia12" value="1" />
+    </path>
+
+    <path name="compress-offload-playback5 usb-headphones">
+        <path name="compress-offload-playback5 afe-proxy" />
+    </path>
+
+    <path name="compress-offload-playback5 speaker-and-usb-headphones">
+        <path name="compress-offload-playback5 usb-headphones" />
+        <path name="compress-offload-playback5" />
+    </path>
+
+    <path name="compress-offload-playback5 headphones">
+        <path name="compress-offload-playback5" />
+    </path>
+
+    <path name="compress-offload-playback5 headphones-44.1">
+        <ctl name="SLIMBUS_5_RX Audio Mixer MultiMedia12" value="1" />
+    </path>
+
+    <path name="compress-offload-playback6">
+        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia13" value="1" />
+    </path>
+
+    <path name="compress-offload-playback6 hdmi">
+        <ctl name="HDMI Mixer MultiMedia13" value="1" />
+    </path>
+
+    <path name="compress-offload-playback6 bt-sco">
+        <ctl name="AUX_PCM_RX Audio Mixer MultiMedia13" value="1" />
+    </path>
+
+    <path name="compress-offload-playback6 bt-sco-wb">
+        <ctl name="AUX PCM SampleRate" value="16000" />
+        <path name="compress-offload-playback6 bt-sco" />
+    </path>
+
+    <path name="compress-offload-playback6 speaker-and-hdmi">
+        <path name="compress-offload-playback6 hdmi" />
+        <path name="compress-offload-playback6" />
+    </path>
+
+    <path name="compress-offload-playback6 afe-proxy">
+        <ctl name="AFE_PCM_RX Audio Mixer MultiMedia13" value="1" />
+    </path>
+
+    <path name="compress-offload-playback6 usb-headphones">
+        <path name="compress-offload-playback6 afe-proxy" />
+    </path>
+
+    <path name="compress-offload-playback6 speaker-and-usb-headphones">
+        <path name="compress-offload-playback6 usb-headphones" />
+        <path name="compress-offload-playback6" />
+    </path>
+
+    <path name="compress-offload-playback6 headphones">
+        <path name="compress-offload-playback6" />
+    </path>
+
+    <path name="compress-offload-playback6 headphones-44.1">
+        <ctl name="SLIMBUS_5_RX Audio Mixer MultiMedia13" value="1" />
+    </path>
+
+    <path name="compress-offload-playback7">
+        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia14" value="1" />
+    </path>
+
+    <path name="compress-offload-playback7 hdmi">
+        <ctl name="MI2S_HDMI_RX Audio Mixer MultiMedia14" value="1" />
+    </path>
+
+    <path name="compress-offload-playback7 bt-sco">
+        <ctl name="AUX_PCM_RX Audio Mixer MultiMedia14" value="1" />
+    </path>
+
+    <path name="compress-offload-playback7 bt-sco-wb">
+        <ctl name="AUX PCM SampleRate" value="16000" />
+        <path name="compress-offload-playback7 bt-sco" />
+    </path>
+
+    <path name="compress-offload-playback7 speaker-and-hdmi">
+        <path name="compress-offload-playback7 hdmi" />
+        <path name="compress-offload-playback7" />
+    </path>
+
+    <path name="compress-offload-playback7 afe-proxy">
+        <ctl name="AFE_PCM_RX Audio Mixer MultiMedia14" value="1" />
+    </path>
+
+    <path name="compress-offload-playback7 usb-headphones">
+        <path name="compress-offload-playback7 afe-proxy" />
+    </path>
+
+    <path name="compress-offload-playback7 speaker-and-usb-headphones">
+        <path name="compress-offload-playback7 usb-headphones" />
+        <path name="compress-offload-playback7" />
+    </path>
+
+    <path name="compress-offload-playback7 headphones">
+        <path name="compress-offload-playback7" />
+    </path>
+
+    <path name="compress-offload-playback7 headphones-44.1">
+        <ctl name="SLIMBUS_5_RX Audio Mixer MultiMedia14" value="1" />
+    </path>
+
+    <path name="compress-offload-playback8">
+        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia15" value="1" />
+    </path>
+
+    <path name="compress-offload-playback8 hdmi">
+        <ctl name="MI2S_HDMI_RX Audio Mixer MultiMedia15" value="1" />
+    </path>
+
+    <path name="compress-offload-playback8 bt-sco">
+        <ctl name="AUX_PCM_RX Audio Mixer MultiMedia15" value="1" />
+    </path>
+
+    <path name="compress-offload-playback8 bt-sco-wb">
+        <ctl name="AUX PCM SampleRate" value="16000" />
+        <path name="compress-offload-playback8 bt-sco" />
+    </path>
+
+    <path name="compress-offload-playback8 speaker-and-hdmi">
+        <path name="compress-offload-playback8 hdmi" />
+        <path name="compress-offload-playback8" />
+    </path>
+
+    <path name="compress-offload-playback8 afe-proxy">
+        <ctl name="AFE_PCM_RX Audio Mixer MultiMedia15" value="1" />
+    </path>
+
+    <path name="compress-offload-playback8 usb-headphones">
+        <path name="compress-offload-playback8 afe-proxy" />
+    </path>
+
+    <path name="compress-offload-playback8 speaker-and-usb-headphones">
+        <path name="compress-offload-playback8 usb-headphones" />
+        <path name="compress-offload-playback8" />
+    </path>
+
+    <path name="compress-offload-playback8 headphones">
+        <path name="compress-offload-playback8" />
+    </path>
+
+    <path name="compress-offload-playback8 headphones-44.1">
+        <ctl name="SLIMBUS_5_RX Audio Mixer MultiMedia15" value="1" />
+    </path>
+
+    <path name="compress-offload-playback9">
+        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia16" value="1" />
+    </path>
+
+    <path name="compress-offload-playback9 hdmi">
+        <ctl name="MI2S_HDMI_RX Audio Mixer MultiMedia16" value="1" />
+    </path>
+
+    <path name="compress-offload-playback9 bt-sco">
+        <ctl name="AUX_PCM_RX Audio Mixer MultiMedia16" value="1" />
+    </path>
+
+    <path name="compress-offload-playback9 bt-sco-wb">
+        <ctl name="AUX PCM SampleRate" value="16000" />
+        <path name="compress-offload-playback9 bt-sco" />
+    </path>
+
+    <path name="compress-offload-playback9 speaker-and-hdmi">
+        <path name="compress-offload-playback9 hdmi" />
+        <path name="compress-offload-playback9" />
+    </path>
+
+    <path name="compress-offload-playback9 afe-proxy">
+        <ctl name="AFE_PCM_RX Audio Mixer MultiMedia16" value="1" />
+    </path>
+
+    <path name="compress-offload-playback9 usb-headphones">
+        <path name="compress-offload-playback9 afe-proxy" />
+    </path>
+
+    <path name="compress-offload-playback9 speaker-and-usb-headphones">
+        <path name="compress-offload-playback9 usb-headphones" />
+        <path name="compress-offload-playback9" />
+    </path>
+
+    <path name="compress-offload-playback9 headphones">
+        <path name="compress-offload-playback9" />
+    </path>
+
+    <path name="compress-offload-playback9 headphones-44.1">
+        <ctl name="SLIMBUS_5_RX Audio Mixer MultiMedia16" value="1" />
+    </path>
+
+    <path name="audio-record">
+        <ctl name="MultiMedia1 Mixer SLIM_0_TX" value="1" />
+    </path>
+
+    <path name="audio-record usb-headset-mic">
+        <ctl name="MultiMedia1 Mixer AFE_PCM_TX" value="1" />
+    </path>
+
+    <path name="audio-record bt-sco">
+        <ctl name="MultiMedia1 Mixer AUX_PCM_UL_TX" value="1" />
+    </path>
+
+    <path name="audio-record bt-sco-wb">
+        <ctl name="AUX PCM SampleRate" value="16000" />
+        <path name="audio-record bt-sco" />
+    </path>
+
+    <path name="audio-record capture-fm">
+        <ctl name="MultiMedia1 Mixer QUIN_MI2S_TX" value="1" />
+    </path>
+
+    <path name="audio-record capture-ahc">
+        <ctl name="MultiMedia1 Mixer SLIM_0_TX" value="1" />
+    </path>
+
+    <path name="audio-record-compress">
+        <ctl name="MultiMedia8 Mixer SLIM_0_TX" value="1" />
+    </path>
+
+    <path name="audio-record-compress bt-sco">
+        <ctl name="MultiMedia8 Mixer AUX_PCM_TX" value="1" />
+    </path>
+
+    <path name="audio-record-compress bt-sco-wb">
+        <ctl name="AUX PCM SampleRate" value="16000" />
+        <path name="audio-record-compress bt-sco" />
+    </path>
+
+    <path name="audio-record-compress usb-headset-mic">
+        <ctl name="MultiMedia8 Mixer AFE_PCM_TX" value="1" />
+    </path>
+
+    <path name="low-latency-record">
+        <ctl name="MultiMedia5 Mixer SLIM_0_TX" value="1" />
+    </path>
+
+    <path name="low-latency-record bt-sco">
+      <ctl name="MultiMedia5 Mixer AUX_PCM_TX" value="1" />
+    </path>
+
+    <path name="low-latency-record bt-sco-wb">
+        <ctl name="AUX PCM SampleRate" value="16000" />
+        <path name="low-latency-record bt-sco" />
+    </path>
+
+    <path name="fm-virtual-record capture-fm">
+        <ctl name="MultiMedia2 Mixer QUIN_MI2S_TX" value="1" />
+    </path>
+
+    <path name="voice-call">
+        <ctl name="SLIM_0_RX_Voice Mixer CSVoice" value="1" />
+        <ctl name="Voice_Tx Mixer SLIM_0_TX_Voice" value="1" />
+    </path>
+
+    <path name="voice-call hdmi">
+        <ctl name="HDMI_RX_Voice Mixer CSVoice" value="1" />
+        <ctl name="Voice_Tx Mixer SLIM_0_TX_Voice" value="1" />
+    </path>
+
+    <path name="voice-call bt-sco">
+        <ctl name="AUX_PCM_RX_Voice Mixer CSVoice" value="1" />
+        <ctl name="Voice_Tx Mixer AUX_PCM_TX_Voice" value="1" />
+    </path>
+
+    <path name="voice-call bt-sco-wb">
+        <ctl name="AUX PCM SampleRate" value="16000" />
+        <path name="voice-call bt-sco" />
+    </path>
+
+    <path name="voice-call afe-proxy">
+        <ctl name="AFE_PCM_RX_Voice Mixer CSVoice" value="1" />
+        <ctl name="Voice_Tx Mixer AFE_PCM_TX_Voice" value="1" />
+    </path>
+
+    <path name="voice-call usb-headphones">
+        <ctl name="AFE_PCM_RX_Voice Mixer CSVoice" value="1" />
+        <ctl name="Voice_Tx Mixer AFE_PCM_TX_Voice" value="1" />
+    </path>
+
+    <path name="voice2-call">
+        <ctl name="SLIM_0_RX_Voice Mixer Voice2" value="1" />
+        <ctl name="Voice2_Tx Mixer SLIM_0_TX_Voice2" value="1" />
+    </path>
+
+    <path name="voice-call vbat-voice-speaker">
+        <path name="vbat-speaker-mono echo-reference" />
+        <path name="voice-call"/>
+    </path>
+
+    <path name="voice-call incall-music">
+        <path name="voice-call"/>
+    </path>
+
+    <path name="voice-call incall-music-bt">
+        <path name="voice-call bt-sco"/>
+    </path>
+
+    <path name="voice-call incall-music-bt-wb">
+        <ctl name="AUX PCM SampleRate" value="16000" />
+        <path name="voice-call incall-music-bt" />
+    </path>
+
+    <path name="voice2-call hdmi">
+        <ctl name="HDMI_RX_Voice Mixer Voice2" value="1" />
+        <ctl name="Voice2_Tx Mixer SLIM_0_TX_Voice2" value="1" />
+    </path>
+
+    <path name="voice2-call bt-sco">
+        <ctl name="AUX_PCM_RX_Voice Mixer Voice2" value="1" />
+        <ctl name="Voice2_Tx Mixer AUX_PCM_TX_Voice2" value="1" />
+    </path>
+
+    <path name="voice2-call bt-sco-wb">
+        <ctl name="AUX PCM SampleRate" value="16000" />
+        <path name="voice2-call bt-sco" />
+    </path>
+
+    <path name="voice2-call afe-proxy">
+        <ctl name="AFE_PCM_RX_Voice Mixer Voice2" value="1" />
+        <ctl name="Voice2_Tx Mixer AFE_PCM_TX_Voice2" value="1" />
+    </path>
+
+    <path name="voice2-call usb-headphones">
+        <ctl name="AFE_PCM_RX_Voice Mixer Voice2" value="1" />
+        <ctl name="Voice2_Tx Mixer AFE_PCM_TX_Voice2" value="1" />
+    </path>
+
+    <path name="voice2-call vbat-voice-speaker">
+        <path name="vbat-speaker-mono echo-reference" />
+        <path name="voice2-call"/>
+    </path>
+
+    <path name="voice2-call incall-music2">
+        <path name="voice2-call" />
+    </path>
+
+    <path name="voice2-call incall-music2-bt">
+        <path name="voice2-call bt-sco" />
+    </path>
+
+    <path name="voice2-call incall-music2-bt-wb">
+        <ctl name="AUX PCM SampleRate" value="16000" />
+        <path name="voice2-call incall-music2-bt" />
+    </path>
+
+    <path name="play-fm">
+        <ctl name="Quin MI2S LOOPBACK Volume" value="1" />
+        <ctl name="SLIMBUS_0_RX Port Mixer QUIN_MI2S_TX" value="1" />
+        <ctl name="SLIMBUS_DL_HL Switch" value="1" />
+    </path>
+
+    <path name="incall-rec-uplink">
+        <ctl name="MultiMedia1 Mixer VOC_REC_UL" value="1" />
+    </path>
+
+    <path name="incall-rec-uplink bt-sco">
+        <path name="incall-rec-uplink" />
+    </path>
+
+    <path name="incall-rec-uplink bt-sco-wb">
+        <path name="incall-rec-uplink" />
+    </path>
+
+    <path name="incall-rec-uplink usb-headset-mic">
+        <path name="incall-rec-uplink" />
+    </path>
+
+    <path name="incall-rec-uplink afe-proxy">
+        <path name="incall-rec-uplink" />
+    </path>
+
+    <path name="incall-rec-uplink-compress">
+        <ctl name="MultiMedia8 Mixer VOC_REC_UL" value="1" />
+    </path>
+
+    <path name="incall-rec-uplink-compress bt-sco">
+        <path name="incall-rec-uplink-compress" />
+    </path>
+
+    <path name="incall-rec-uplink-compress bt-sco-wb">
+        <path name="incall-rec-uplink-compress" />
+    </path>
+
+    <path name="incall-rec-uplink-compress usb-headset-mic">
+        <path name="incall-rec-uplink-compress" />
+    </path>
+
+    <path name="incall-rec-uplink-compress afe-proxy">
+        <path name="incall-rec-uplink-compress" />
+    </path>
+
+    <path name="incall-rec-downlink">
+        <ctl name="MultiMedia1 Mixer VOC_REC_DL"  value="1" />
+    </path>
+
+    <path name="incall-rec-downlink bt-sco">
+        <path name="incall-rec-downlink" />
+    </path>
+
+    <path name="incall-rec-downlink bt-sco-wb">
+        <path name="incall-rec-downlink" />
+    </path>
+
+    <path name="incall-rec-downlink usb-headset-mic">
+        <path name="incall-rec-downlink" />
+    </path>
+
+    <path name="incall-rec-downlink afe-proxy">
+        <path name="incall-rec-downlink" />
+    </path>
+
+    <path name="incall-rec-downlink-compress">
+        <ctl name="MultiMedia8 Mixer VOC_REC_DL" value="1" />
+    </path>
+
+    <path name="incall-rec-downlink-compress bt-sco">
+        <path name="incall-rec-downlink-compress" />
+    </path>
+
+    <path name="incall-rec-downlink-compress bt-sco-wb">
+        <path name="incall-rec-downlink-compress" />
+    </path>
+
+    <path name="incall-rec-downlink-compress usb-headset-mic">
+        <path name="incall-rec-downlink-compress" />
+    </path>
+
+    <path name="incall-rec-downlink-compress afe-proxy">
+        <path name="incall-rec-downlink-compress" />
+    </path>
+
+    <path name="incall-rec-uplink-and-downlink">
+        <path name="incall-rec-uplink" />
+        <path name="incall-rec-downlink" />
+    </path>
+
+    <path name="incall-rec-uplink-and-downlink bt-sco">
+        <path name="incall-rec-uplink-and-downlink" />
+    </path>
+
+    <path name="incall-rec-uplink-and-downlink bt-sco-wb">
+        <path name="incall-rec-uplink-and-downlink" />
+    </path>
+
+    <path name="incall-rec-uplink-and-downlink usb-headset-mic">
+        <path name="incall-rec-uplink-and-downlink" />
+    </path>
+
+    <path name="incall-rec-uplink-and-downlink afe-proxy">
+        <path name="incall-rec-uplink-and-downlink" />
+    </path>
+
+    <path name="incall-rec-uplink-and-downlink-compress">
+        <path name="incall-rec-uplink-compress" />
+        <path name="incall-rec-downlink-compress" />
+    </path>
+
+    <path name="incall-rec-uplink-and-downlink-compress bt-sco">
+        <path name="incall-rec-uplink-and-downlink-compress" />
+    </path>
+
+    <path name="incall-rec-uplink-and-downlink-compress bt-sco-wb">
+        <path name="incall-rec-uplink-and-downlink-compress" />
+    </path>
+
+    <path name="incall-rec-uplink-and-downlink-compress usb-headset-mic">
+        <path name="incall-rec-uplink-and-downlink-compress" />
+    </path>
+
+    <path name="incall-rec-uplink-and-downlink-compress afe-proxy">
+        <path name="incall-rec-uplink-and-downlink-compress" />
+    </path>
+
+    <path name="hfp-sco">
+        <ctl name="HFP_INT_UL_HL Switch" value="1" />
+        <ctl name="SLIMBUS_0_RX Port Mixer AUX_PCM_UL_TX" value="1" />
+        <ctl name="AUX_PCM_RX Audio Mixer MultiMedia6" value="1" />
+        <ctl name="MultiMedia6 Mixer SLIM_0_TX" value="1" />
+        <ctl name="SLIMBUS_DL_HL Switch" value="1" />
+   </path>
+
+   <path name="hfp-sco-wb">
+        <ctl name="AUX PCM SampleRate" value="16000" />
+        <path name="hfp-sco" />
+   </path>
+
+    <path name="volte-call">
+        <ctl name="SLIM_0_RX_Voice Mixer VoLTE" value="1" />
+        <ctl name="VoLTE_Tx Mixer SLIM_0_TX_VoLTE" value="1" />
+    </path>
+
+    <path name="volte-call hdmi">
+        <ctl name="HDMI_RX_Voice Mixer VoLTE" value="1" />
+        <ctl name="VoLTE_Tx Mixer SLIM_0_TX_VoLTE" value="1" />
+    </path>
+
+    <path name="volte-call bt-sco">
+        <ctl name="AUX_PCM_RX_Voice Mixer VoLTE" value="1" />
+        <ctl name="VoLTE_Tx Mixer AUX_PCM_TX_VoLTE" value="1" />
+    </path>
+
+    <path name="volte-call bt-sco-wb">
+        <ctl name="AUX PCM SampleRate" value="16000" />
+        <path name="volte-call bt-sco" />
+    </path>
+
+    <path name="volte-call afe-proxy">
+        <ctl name="AFE_PCM_RX_Voice Mixer VoLTE" value="1" />
+        <ctl name="VoLTE_Tx Mixer AFE_PCM_TX_VoLTE" value="1" />
+    </path>
+
+    <path name="volte-call usb-headphones">
+        <ctl name="AFE_PCM_RX_Voice Mixer VoLTE" value="1" />
+        <ctl name="VoLTE_Tx Mixer AFE_PCM_TX_VoLTE" value="1" />
+    </path>
+
+    <path name="volte-call vbat-voice-speaker">
+        <path name="vbat-speaker-mono echo-reference" />
+        <path name="volte-call"/>
+    </path>
+
+    <path name="volte-call incall-music">
+        <path name="volte-call"/>
+    </path>
+
+    <path name="volte-call incall-music-bt">
+        <path name="volte-call bt-sco"/>
+    </path>
+
+    <path name="volte-call incall-music-bt-wb">
+        <ctl name="AUX PCM SampleRate" value="16000" />
+        <path name="volte-call incall-music-bt" />
+    </path>
+
+    <path name="compress-voip-call">
+        <ctl name="SLIM_0_RX_Voice Mixer Voip" value="1" />
+        <ctl name="Voip_Tx Mixer SLIM_0_TX_Voip" value="1" />
+    </path>
+
+    <path name="compress-voip-call bt-sco">
+        <ctl name="AUX_PCM_RX_Voice Mixer Voip" value="1" />
+        <ctl name="Voip_Tx Mixer AUX_PCM_TX_Voip" value="1" />
+    </path>
+
+    <path name="compress-voip-call bt-sco-wb">
+        <ctl name="AUX PCM SampleRate" value="16000" />
+        <path name="compress-voip-call bt-sco" />
+    </path>
+
+    <path name="compress-voip-call afe-proxy">
+        <ctl name="AFE_PCM_RX_Voice Mixer Voip" value="1" />
+        <ctl name="Voip_Tx Mixer AFE_PCM_TX_Voip" value="1" />
+    </path>
+
+    <path name="compress-voip-call usb-headphones">
+        <ctl name="AFE_PCM_RX_Voice Mixer Voip" value="1" />
+        <ctl name="Voip_Tx Mixer AFE_PCM_TX_Voip" value="1" />
+    </path>
+
+    <path name="compress-voip-call vbat-voice-speaker">
+        <path name="vbat-speaker-mono echo-reference" />
+        <path name="compress-voip-call"/>
+    </path>
+
+    <path name="vowlan-call">
+        <ctl name="SLIM_0_RX_Voice Mixer VoWLAN" value="1" />
+        <ctl name="VoWLAN_Tx Mixer SLIM_0_TX_VoWLAN" value="1" />
+    </path>
+
+    <path name="vowlan-call hdmi">
+        <ctl name="HDMI_RX_Voice Mixer VoWLAN" value="1" />
+        <ctl name="VoWLAN_Tx Mixer SLIM_0_TX_VoWLAN" value="1" />
+    </path>
+
+    <path name="vowlan-call bt-sco">
+        <ctl name="AUX_PCM_RX_Voice Mixer VoWLAN" value="1" />
+        <ctl name="VoWLAN_Tx Mixer AUX_PCM_TX_VoWLAN" value="1" />
+    </path>
+
+    <path name="vowlan-call bt-sco-wb">
+        <ctl name="AUX PCM SampleRate" value="16000" />
+        <path name="vowlan-call bt-sco" />
+    </path>
+
+    <path name="vowlan-call afe-proxy">
+        <ctl name="AFE_PCM_RX_Voice Mixer VoWLAN" value="1" />
+        <ctl name="VoWLAN_Tx Mixer AFE_PCM_TX_VoWLAN" value="1" />
+    </path>
+
+    <path name="vowlan-call usb-headphones">
+        <ctl name="AFE_PCM_RX_Voice Mixer VoWLAN" value="1" />
+        <ctl name="VoWLAN_Tx Mixer AFE_PCM_TX_VoWLAN" value="1" />
+    </path>
+
+    <path name="vowlan-call vbat-voice-speaker">
+        <path name="vbat-speaker-mono echo-reference" />
+        <path name="vowlan-call"/>
+    </path>
+
+    <path name="voicemmode1-call">
+        <ctl name="SLIM_0_RX_Voice Mixer VoiceMMode1" value="1" />
+        <ctl name="VoiceMMode1_Tx Mixer SLIM_0_TX_MMode1" value="1" />
+    </path>
+
+    <path name="voicemmode1-call hdmi">
+        <ctl name="HDMI_RX_Voice Mixer VoiceMMode1" value="1" />
+        <ctl name="VoiceMMode1_Tx Mixer SLIM_0_TX_MMode1" value="1" />
+    </path>
+
+    <path name="voicemmode1-call bt-sco">
+        <ctl name="AUX_PCM_RX_Voice Mixer VoiceMMode1" value="1" />
+        <ctl name="VoiceMMode1_Tx Mixer AUX_PCM_TX_MMode1" value="1" />
+    </path>
+
+    <path name="voicemmode1-call bt-sco-wb">
+        <ctl name="AUX PCM SampleRate" value="16000" />
+        <path name="voicemmode1-call bt-sco" />
+    </path>
+
+    <path name="voicemmode1-call afe-proxy">
+        <ctl name="AFE_PCM_RX_Voice Mixer VoiceMMode1" value="1" />
+        <ctl name="VoiceMMode1_Tx Mixer AFE_PCM_TX_MMode1" value="1" />
+    </path>
+
+    <path name="voicemmode1-call usb-headphones">
+        <ctl name="AFE_PCM_RX_Voice Mixer VoiceMMode1" value="1" />
+        <ctl name="VoiceMMode1_Tx Mixer AFE_PCM_TX_MMode1" value="1" />
+    </path>
+
+    <path name="voicemmode1-call vbat-voice-speaker">
+        <path name="vbat-speaker-mono echo-reference" />
+        <path name="voicemmode1-call"/>
+    </path>
+
+    <path name="voicemmode1-call incall-music">
+        <path name="voicemmode1-call" />
+    </path>
+
+    <path name="voicemmode1-call incall-music-bt">
+        <path name="voicemmode1-call bt-sco"/>
+    </path>
+
+    <path name="voicemmode1-call incall-music-bt-wb">
+        <ctl name="AUX PCM SampleRate" value="16000" />
+        <path name="voicemmode1-call incall-music-bt" />
+    </path>
+
+    <path name="voicemmode2-call">
+        <ctl name="SLIM_0_RX_Voice Mixer VoiceMMode2" value="1" />
+        <ctl name="VoiceMMode2_Tx Mixer SLIM_0_TX_MMode2" value="1" />
+    </path>
+
+    <path name="voicemmode2-call hdmi">
+        <ctl name="HDMI_RX_Voice Mixer VoiceMMode2" value="1" />
+        <ctl name="VoiceMMode2_Tx Mixer SLIM_0_TX_MMode2" value="1" />
+    </path>
+
+    <path name="voicemmode2-call bt-sco">
+        <ctl name="AUX_PCM_RX_Voice Mixer VoiceMMode2" value="1" />
+        <ctl name="VoiceMMode2_Tx Mixer AUX_PCM_TX_MMode2" value="1" />
+    </path>
+
+    <path name="voicemmode2-call bt-sco-wb">
+        <ctl name="AUX PCM SampleRate" value="16000" />
+        <path name="voicemmode2-call bt-sco" />
+    </path>
+
+    <path name="voicemmode2-call afe-proxy">
+        <ctl name="AFE_PCM_RX_Voice Mixer VoiceMMode2" value="1" />
+        <ctl name="VoiceMMode2_Tx Mixer AFE_PCM_TX_MMode2" value="1" />
+    </path>
+
+    <path name="voicemmode2-call usb-headphones">
+        <ctl name="AFE_PCM_RX_Voice Mixer VoiceMMode2" value="1" />
+        <ctl name="VoiceMMode2_Tx Mixer AFE_PCM_TX_MMode2" value="1" />
+    </path>
+
+    <path name="voicemmode2-call vbat-voice-speaker">
+        <path name="vbat-speaker-mono echo-reference" />
+        <path name="voicemmode2-call"/>
+    </path>
+
+    <path name="voicemmode2-call incall-music2">
+        <path name="voicemmode2-call" />
+    </path>
+
+    <path name="voicemmode2-call incall-music2-bt">
+        <path name="voicemmode2-call bt-sco"/>
+    </path>
+
+    <path name="voicemmode2-call incall-music2-bt-wb">
+        <ctl name="AUX PCM SampleRate" value="16000" />
+        <path name="voicemmode2-call incall-music2-bt" />
+    </path>
+
+    <path name="listen-voice-wakeup-1">
+        <ctl name="LSM1 MUX" value="SLIMBUS_5_TX" />
+        <ctl name="SLIMBUS_5_TX LSM Function" value="AUDIO" />
+    </path>
+    <path name="listen-voice-wakeup-2">
+        <ctl name="LSM2 MUX" value="SLIMBUS_5_TX" />
+        <ctl name="SLIMBUS_5_TX LSM Function" value="AUDIO" />
+    </path>
+    <path name="listen-voice-wakeup-3">
+        <ctl name="LSM3 MUX" value="SLIMBUS_5_TX" />
+        <ctl name="SLIMBUS_5_TX LSM Function" value="AUDIO" />
+    </path>
+    <path name="listen-voice-wakeup-4">
+        <ctl name="LSM4 MUX" value="SLIMBUS_5_TX" />
+        <ctl name="SLIMBUS_5_TX LSM Function" value="AUDIO" />
+    </path>
+    <path name="listen-voice-wakeup-5">
+        <ctl name="LSM5 MUX" value="SLIMBUS_5_TX" />
+        <ctl name="SLIMBUS_5_TX LSM Function" value="AUDIO" />
+    </path>
+    <path name="listen-voice-wakeup-6">
+        <ctl name="LSM6 MUX" value="SLIMBUS_5_TX" />
+        <ctl name="SLIMBUS_5_TX LSM Function" value="AUDIO" />
+    </path>
+    <path name="listen-voice-wakeup-7">
+        <ctl name="LSM7 MUX" value="SLIMBUS_5_TX" />
+        <ctl name="SLIMBUS_5_TX LSM Function" value="AUDIO" />
+    </path>
+    <path name="listen-voice-wakeup-8">
+        <ctl name="LSM8 MUX" value="SLIMBUS_5_TX" />
+        <ctl name="SLIMBUS_5_TX LSM Function" value="AUDIO" />
+    </path>
+
+   <path name="spkr-rx-calib">
+        <ctl name="SLIMBUS_DL_HL Switch"  value="1" />
+    </path>
+
+    <path name="spkr-vi-record">
+        <ctl name="SLIM0_RX_VI_FB_LCH_MUX"  value="SLIM4_TX" />
+    </path>
+
+    <!-- These are actual sound device specific mixer settings -->
+    <path name="adc1">
+        <ctl name="AIF1_CAP Mixer SLIM TX6" value="1"/>
+        <ctl name="SLIM_0_TX Channels" value="One" />
+        <ctl name="SLIM TX6 MUX" value="DEC6" />
+        <ctl name="ADC MUX6" value="AMIC" />
+        <ctl name="AMIC MUX6" value="ADC1" />
+        <ctl name="IIR0 INP0 MUX" value="DEC6" />
+    </path>
+
+    <path name="adc2">
+        <ctl name="AIF1_CAP Mixer SLIM TX0" value="1"/>
+        <ctl name="SLIM_0_TX Channels" value="One" />
+        <ctl name="SLIM TX0 MUX" value="DEC0" />
+        <ctl name="ADC MUX0" value="AMIC" />
+        <ctl name="AMIC MUX0" value="ADC2" />
+        <ctl name="IIR0 INP0 MUX" value="DEC0" />
+    </path>
+
+    <path name="adc5">
+        <ctl name="AIF1_CAP Mixer SLIM TX5" value="1"/>
+        <ctl name="SLIM_0_TX Channels" value="One" />
+        <ctl name="SLIM TX5 MUX" value="DEC5" />
+        <ctl name="ADC MUX5" value="AMIC" />
+        <ctl name="AMIC MUX5" value="ADC5" />
+        <ctl name="IIR0 INP0 MUX" value="DEC5" />
+    </path>
+
+    <path name="adc6">
+        <ctl name="AIF1_CAP Mixer SLIM TX7" value="1"/>
+        <ctl name="SLIM_0_TX Channels" value="One" />
+        <ctl name="SLIM TX7 MUX" value="DEC7" />
+        <ctl name="ADC MUX7" value="AMIC" />
+        <ctl name="AMIC MUX7" value="ADC6" />
+        <ctl name="IIR0 INP0 MUX" value="DEC7" />
+    </path>
+
+    <!-- Gain offset target for dmic1 unit calibration -->
+    <path name="dmic1-adj-gain">
+        <ctl name="DEC7 Volume" value="104" />
+    </path>
+
+    <!-- Gain offset target for dmic2 unit calibration -->
+    <path name="dmic2-adj-gain">
+        <ctl name="DEC8 Volume" value="84" />
+    </path>
+
+    <!-- For Tasha, DMIC numbered from 0 to 5 -->
+    <path name="dmic3">
+        <ctl name="AIF1_CAP Mixer SLIM TX7" value="1"/>
+        <ctl name="SLIM_0_TX Channels" value="One" />
+        <ctl name="SLIM TX7 MUX" value="DEC7" />
+        <ctl name="ADC MUX7" value="DMIC" />
+        <ctl name="DMIC MUX7" value="DMIC2" />
+        <ctl name="IIR0 INP0 MUX" value="DEC7" />
+    </path>
+
+    <path name="dmic1">
+        <ctl name="AIF1_CAP Mixer SLIM TX7" value="1"/>
+        <ctl name="SLIM_0_TX Channels" value="One" />
+        <ctl name="SLIM TX7 MUX" value="DEC7" />
+        <ctl name="ADC MUX7" value="DMIC" />
+        <ctl name="DMIC MUX7" value="DMIC0" />
+        <ctl name="IIR0 INP0 MUX" value="DEC7" />
+    </path>
+
+    <path name="dmic2">
+        <ctl name="AIF1_CAP Mixer SLIM TX7" value="1"/>
+        <ctl name="SLIM_0_TX Channels" value="One" />
+        <ctl name="SLIM TX7 MUX" value="DEC7" />
+        <ctl name="ADC MUX7" value="DMIC" />
+        <ctl name="DMIC MUX7" value="DMIC1" />
+        <ctl name="IIR0 INP0 MUX" value="DEC7" />
+    </path>
+
+    <path name="dmic4">
+        <ctl name="AIF1_CAP Mixer SLIM TX8" value="1"/>
+        <ctl name="SLIM_0_TX Channels" value="One" />
+        <ctl name="SLIM TX8 MUX" value="DEC8" />
+        <ctl name="ADC MUX8" value="DMIC" />
+        <ctl name="DMIC MUX8" value="DMIC3" />
+        <ctl name="IIR0 INP0 MUX" value="DEC8" />
+    </path>
+
+    <path name="dmic5">
+        <ctl name="AIF1_CAP Mixer SLIM TX7" value="1"/>
+        <ctl name="SLIM_0_TX Channels" value="One" />
+        <ctl name="SLIM TX7 MUX" value="DEC7" />
+        <ctl name="ADC MUX7" value="DMIC" />
+        <ctl name="DMIC MUX7" value="DMIC4" />
+        <ctl name="IIR0 INP0 MUX" value="DEC7" />
+    </path>
+
+    <path name="dmic6">
+        <ctl name="AIF1_CAP Mixer SLIM TX7" value="1"/>
+        <ctl name="SLIM_0_TX Channels" value="One" />
+        <ctl name="SLIM TX7 MUX" value="DEC7" />
+        <ctl name="ADC MUX7" value="DMIC" />
+        <ctl name="DMIC MUX7" value="DMIC5" />
+        <ctl name="IIR0 INP0 MUX" value="DEC7" />
+    </path>
+
+    <path name="wsa-speaker">
+        <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM RX1 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM_0_RX Channels" value="Two" />
+        <ctl name="RX INT7_1 MIX1 INP0" value="RX0" />
+        <ctl name="RX INT8_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX7 Digital Volume" value="86" />
+        <ctl name="RX8 Digital Volume" value="86" />
+        <ctl name="SpkrLeft COMP Switch" value="1" />
+        <ctl name="SpkrRight COMP Switch" value="1" />
+        <ctl name="SpkrLeft BOOST Switch" value="1" />
+        <ctl name="SpkrRight BOOST Switch" value="1" />
+        <ctl name="SpkrLeft VISENSE Switch" value="1" />
+        <ctl name="SpkrRight VISENSE Switch" value="1" />
+        <ctl name="SpkrLeft SWR DAC_Port Switch" value="1" />
+        <ctl name="SpkrRight SWR DAC_Port Switch" value="1" />
+    </path>
+
+    <path name="wsa-speaker-mono">
+        <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM_0_RX Channels" value="One" />
+        <ctl name="RX INT7_1 MIX1 INP0" value="RX0" />
+        <ctl name="SpkrLeft COMP Switch" value="1" />
+        <ctl name="SpkrLeft BOOST Switch" value="1" />
+        <ctl name="SpkrLeft VISENSE Switch" value="1" />
+        <ctl name="SpkrLeft SWR DAC_Port Switch" value="1" />
+    </path>
+
+    <path name="speaker">
+        <ctl name="AIF4_VI Mixer SPKR_VI_1" value="1" />
+        <ctl name="AIF4_VI Mixer SPKR_VI_2" value="1" />
+        <ctl name="SLIM_4_TX Format" value="PACKED_16B" />
+        <path name="wsa-speaker" />
+        <ctl name="VI_FEED_TX Channels" value="Two" />
+        <ctl name="SLIM0_RX_VI_FB_LCH_MUX"  value="SLIM4_TX" />
+        <ctl name="SLIM0_RX_VI_FB_RCH_MUX"  value="SLIM4_TX" />
+    </path>
+
+    <path name="speaker-reverse">
+        <path name="speaker" />
+        <ctl name="Set Custom Stereo" value="Swap" />
+    </path>
+
+    <path name="fm-speaker">
+        <path name="speaker" />
+    </path>
+
+    <path name="fm-speaker-reverse">
+        <path name="speaker-reverse" />
+    </path>
+
+    <path name="ringtone-speaker">
+        <path name="speaker" />
+        <ctl name="Set Custom Stereo" value="Mix" />
+    </path>
+
+    <path name="ringtone-speaker-mono">
+        <path name="speaker" />
+        <ctl name="Set Custom Stereo" value="Mix" />
+    </path>
+
+
+   <path name="vbat-speaker-mono">
+       <path name="wsa-speaker-mono" />
+       <ctl name="RX INT7 VBAT SPKRL VBAT Enable" value="1" />
+   </path>
+
+   <path name="vbat-speaker">
+       <path name="wsa-speaker" />
+       <ctl name="RX INT7 VBAT SPKRL VBAT Enable" value="1" />
+       <ctl name="RX INT8 VBAT SPKRR VBAT Enable" value="1" />
+   </path>
+
+   <path name="sidetone-iir">
+        <!-- Sidetone settings -->
+        <ctl name="IIR0 Band1" id ="0" value="268435456" />
+        <ctl name="IIR0 Band1" id ="1" value="443935179" />
+        <ctl name="IIR0 Band1" id ="2" value="269358496" />
+        <ctl name="IIR0 Band1" id ="3" value="955060837" />
+        <ctl name="IIR0 Band1" id ="4" value="33343805" />
+        <ctl name="IIR0 Band2" id ="0" value="268435456" />
+        <ctl name="IIR0 Band2" id ="1" value="7710844" />
+        <ctl name="IIR0 Band2" id ="2" value="268283273" />
+        <ctl name="IIR0 Band2" id ="3" value="840117549" />
+        <ctl name="IIR0 Band2" id ="4" value="139712744" />
+        <ctl name="IIR0 Band3" id ="0" value="258528060" />
+        <ctl name="IIR0 Band3" id ="1" value="556685704" />
+        <ctl name="IIR0 Band3" id ="2" value="258528060" />
+        <ctl name="IIR0 Band3" id ="3" value="556885097" />
+        <ctl name="IIR0 Band3" id ="4" value="248820056" />
+        <ctl name="IIR0 Band4" id ="0" value="230046983" />
+        <ctl name="IIR0 Band4" id ="1" value="613647857" />
+        <ctl name="IIR0 Band4" id ="2" value="230046983" />
+        <ctl name="IIR0 Band4" id ="3" value="542681029" />
+        <ctl name="IIR0 Band4" id ="4" value="263035084" />
+        <ctl name="IIR0 Band5" id ="0" value="268435456" />
+        <ctl name="IIR0 Band5" id ="1" value="536870912" />
+        <ctl name="IIR0 Band5" id ="2" value="268435456" />
+        <ctl name="IIR0 Band5" id ="3" value="551775077" />
+        <ctl name="IIR0 Band5" id ="4" value="253934019" />
+        <ctl name="IIR0 Enable Band1" value="1" />
+        <ctl name="IIR0 Enable Band2" value="1" />
+        <ctl name="IIR0 Enable Band3" value="1" />
+        <ctl name="IIR0 Enable Band4" value="1" />
+        <ctl name="IIR0 Enable Band5" value="1" />
+    </path>
+
+   <path name="dnc-sidetone-iir">
+        <!-- Sidetone settings for dnc headphones-->
+        <ctl name="IIR0 Band1" id ="0" value="244717785" />
+        <ctl name="IIR0 Band1" id ="1" value="584487463" />
+        <ctl name="IIR0 Band1" id ="2" value="244536643" />
+        <ctl name="IIR0 Band1" id ="3" value="586603217" />
+        <ctl name="IIR0 Band1" id ="4" value="222934725" />
+        <ctl name="IIR0 Band2" id ="0" value="254988673" />
+        <ctl name="IIR0 Band2" id ="1" value="564070928" />
+        <ctl name="IIR0 Band2" id ="2" value="254903359" />
+        <ctl name="IIR0 Band2" id ="3" value="564070928" />
+        <ctl name="IIR0 Band2" id ="4" value="241456576" />
+        <ctl name="IIR0 Band3" id ="0" value="262148187" />
+        <ctl name="IIR0 Band3" id ="1" value="558586675" />
+        <ctl name="IIR0 Band3" id ="2" value="259428435" />
+        <ctl name="IIR0 Band3" id ="3" value="558586675" />
+        <ctl name="IIR0 Band3" id ="4" value="253141167" />
+        <ctl name="IIR0 Band4" id ="0" value="199951029" />
+        <ctl name="IIR0 Band4" id ="1" value="734484348" />
+        <ctl name="IIR0 Band4" id ="2" value="191789762" />
+        <ctl name="IIR0 Band4" id ="3" value="734484348" />
+        <ctl name="IIR0 Band4" id ="4" value="123305335" />
+        <ctl name="IIR0 Band5" id ="0" value="38679721" />
+        <ctl name="IIR0 Band5" id ="1" value="17906314" />
+        <ctl name="IIR0 Band5" id ="2" value="8111731" />
+        <ctl name="IIR0 Band5" id ="3" value="683833586" />
+        <ctl name="IIR0 Band5" id ="4" value="153821665" />
+        <ctl name="IIR0 Enable Band1" value="1" />
+        <ctl name="IIR0 Enable Band2" value="1" />
+        <ctl name="IIR0 Enable Band3" value="1" />
+        <ctl name="IIR0 Enable Band4" value="1" />
+        <ctl name="IIR0 Enable Band5" value="1" />
+    </path>
+
+   <path name="eq1-iir">
+        <!-- Bright EQ settings -->
+        <ctl name="IIR1 Band1" id ="0" value="268435456" />
+        <ctl name="IIR1 Band1" id ="1" value="437586353" />
+        <ctl name="IIR1 Band1" id ="2" value="173832276" />
+        <ctl name="IIR1 Band1" id ="3" value="163410814" />
+        <ctl name="IIR1 Band1" id ="4" value="1059274509" />
+        <ctl name="IIR1 Band2" id ="0" value="268435456" />
+        <ctl name="IIR1 Band2" id ="1" value="646483181" />
+        <ctl name="IIR1 Band2" id ="2" value="167392513" />
+        <ctl name="IIR1 Band2" id ="3" value="810804778" />
+        <ctl name="IIR1 Band2" id ="4" value="202564853" />
+        <ctl name="IIR1 Band3" id ="0" value="268435456" />
+        <ctl name="IIR1 Band3" id ="1" value="815970282" />
+        <ctl name="IIR1 Band3" id ="2" value="203683363" />
+        <ctl name="IIR1 Band3" id ="3" value="607081275" />
+        <ctl name="IIR1 Band3" id ="4" value="214739442" />
+        <ctl name="IIR1 Band4" id ="0" value="268435456" />
+        <ctl name="IIR1 Band4" id ="1" value="701510207" />
+        <ctl name="IIR1 Band4" id ="2" value="227853067" />
+        <ctl name="IIR1 Band4" id ="3" value="713299986" />
+        <ctl name="IIR1 Band4" id ="4" value="220868877" />
+        <ctl name="IIR1 Band5" id ="0" value="268435456" />
+        <ctl name="IIR1 Band5" id ="1" value="635336802" />
+        <ctl name="IIR1 Band5" id ="2" value="222416777" />
+        <ctl name="IIR1 Band5" id ="3" value="645853902" />
+        <ctl name="IIR1 Band5" id ="4" value="221548546" />
+        <ctl name="IIR1 Enable Band1" value="1" />
+        <ctl name="IIR1 Enable Band2" value="1" />
+        <ctl name="IIR1 Enable Band3" value="1" />
+        <ctl name="IIR1 Enable Band4" value="1" />
+        <ctl name="IIR1 Enable Band5" value="1" />
+    </path>
+
+    <path name="binaural-monitoring-iir0">
+        <ctl name="IIR0 Band1" id ="0" value="244717785" />
+        <ctl name="IIR0 Band1" id ="1" value="584487463" />
+        <ctl name="IIR0 Band1" id ="2" value="244536643" />
+        <ctl name="IIR0 Band1" id ="3" value="586603217" />
+        <ctl name="IIR0 Band1" id ="4" value="222934725" />
+        <ctl name="IIR0 Band2" id ="0" value="254988673" />
+        <ctl name="IIR0 Band2" id ="1" value="564070928" />
+        <ctl name="IIR0 Band2" id ="2" value="254903359" />
+        <ctl name="IIR0 Band2" id ="3" value="564070928" />
+        <ctl name="IIR0 Band2" id ="4" value="241456576" />
+        <ctl name="IIR0 Band3" id ="0" value="262148187" />
+        <ctl name="IIR0 Band3" id ="1" value="558586675" />
+        <ctl name="IIR0 Band3" id ="2" value="259428435" />
+        <ctl name="IIR0 Band3" id ="3" value="558586675" />
+        <ctl name="IIR0 Band3" id ="4" value="253141167" />
+        <ctl name="IIR0 Band4" id ="0" value="199951029" />
+        <ctl name="IIR0 Band4" id ="1" value="734484348" />
+        <ctl name="IIR0 Band4" id ="2" value="191789762" />
+        <ctl name="IIR0 Band4" id ="3" value="734484348" />
+        <ctl name="IIR0 Band4" id ="4" value="123305335" />
+        <ctl name="IIR0 Band5" id ="0" value="38679721" />
+        <ctl name="IIR0 Band5" id ="1" value="17906314" />
+        <ctl name="IIR0 Band5" id ="2" value="8111731" />
+        <ctl name="IIR0 Band5" id ="3" value="683833586" />
+        <ctl name="IIR0 Band5" id ="4" value="153821665" />
+        <ctl name="IIR0 Enable Band1" value="1" />
+        <ctl name="IIR0 Enable Band2" value="1" />
+        <ctl name="IIR0 Enable Band3" value="1" />
+        <ctl name="IIR0 Enable Band4" value="1" />
+        <ctl name="IIR0 Enable Band5" value="1" />
+    </path>
+
+    <path name="binaural-monitoring-iir1">
+        <ctl name="IIR1 Band1" id ="0" value="244717785" />
+        <ctl name="IIR1 Band1" id ="1" value="584487463" />
+        <ctl name="IIR1 Band1" id ="2" value="244536643" />
+        <ctl name="IIR1 Band1" id ="3" value="586603217" />
+        <ctl name="IIR1 Band1" id ="4" value="222934725" />
+        <ctl name="IIR1 Band2" id ="0" value="254988673" />
+        <ctl name="IIR1 Band2" id ="1" value="564070928" />
+        <ctl name="IIR1 Band2" id ="2" value="254903359" />
+        <ctl name="IIR1 Band2" id ="3" value="564070928" />
+        <ctl name="IIR1 Band2" id ="4" value="241456576" />
+        <ctl name="IIR1 Band3" id ="0" value="262148187" />
+        <ctl name="IIR1 Band3" id ="1" value="558586675" />
+        <ctl name="IIR1 Band3" id ="2" value="259428435" />
+        <ctl name="IIR1 Band3" id ="3" value="558586675" />
+        <ctl name="IIR1 Band3" id ="4" value="253141167" />
+        <ctl name="IIR1 Band4" id ="0" value="199951029" />
+        <ctl name="IIR1 Band4" id ="1" value="734484348" />
+        <ctl name="IIR1 Band4" id ="2" value="191789762" />
+        <ctl name="IIR1 Band4" id ="3" value="734484348" />
+        <ctl name="IIR1 Band4" id ="4" value="123305335" />
+        <ctl name="IIR1 Band5" id ="0" value="38679721" />
+        <ctl name="IIR1 Band5" id ="1" value="17906314" />
+        <ctl name="IIR1 Band5" id ="2" value="8111731" />
+        <ctl name="IIR1 Band5" id ="3" value="683833586" />
+        <ctl name="IIR1 Band5" id ="4" value="153821665" />
+        <ctl name="IIR1 Enable Band1" value="1" />
+        <ctl name="IIR1 Enable Band2" value="1" />
+        <ctl name="IIR1 Enable Band3" value="1" />
+        <ctl name="IIR1 Enable Band4" value="1" />
+        <ctl name="IIR1 Enable Band5" value="1" />
+    </path>
+
+    <path name="sidetone-headphones">
+        <path name="sidetone-iir" />
+        <!-- 45 % of 124 (range 0 - 124) Register: 0x340 -->
+        <ctl name="IIR0 INP0 Volume" value="32" />
+        <ctl name="RX INT1 MIX2 INP" value="SRC0" />
+        <ctl name="RX INT2 MIX2 INP" value="SRC0" />
+    </path>
+
+    <path name="dnc-sidetone-headphones">
+        <path name="dnc-sidetone-iir" />
+        <!-- 45 % of 124 (range 0 - 124) Register: 0x340 -->
+        <ctl name="IIR0 INP0 Volume" value="68" />
+        <ctl name="IIR0 INP1 Volume" value="68" />
+        <ctl name="RX INT1 MIX2 INP" value="SRC0" />
+        <ctl name="RX INT2 MIX2 INP" value="SRC0" />
+    </path>
+
+    <path name="sidetone-handset">
+        <path name="sidetone-iir" />
+        <!-- 33 % of 124 (range 0 - 124) Register: 0x340 -->
+        <ctl name="IIR0 INP0 Volume" value="41" />
+        <ctl name="RX INT0 MIX2 INP" value="SRC0" />
+    </path>
+
+    <path name="speaker-mic">
+        <path name="dmic4" />
+        <path name="dmic2-adj-gain" />
+        <ctl name="RX7 Digital Volume" value="0" />
+    </path>
+
+    <path name="stereo-mic-common">
+        <ctl name="AIF1_CAP Mixer SLIM TX7" value="1" />
+        <ctl name="AIF1_CAP Mixer SLIM TX8" value="1" />
+        <ctl name="SLIM_0_TX Channels" value="Two" />
+        <ctl name="TX8 HPF cut off" value="CF_NEG_3DB_4HZ" />
+        <ctl name="TX7 HPF cut off" value="CF_NEG_3DB_4HZ" />
+        <ctl name="SLIM TX7 MUX" value="DEC7" />
+        <ctl name="SLIM TX8 MUX" value="DEC8" />
+        <ctl name="ADC MUX8" value="DMIC" />
+        <ctl name="DMIC MUX8" value="DMIC0" />
+        <ctl name="ADC MUX7" value="DMIC" />
+        <ctl name="DMIC MUX7" value="DMIC3" />
+        <ctl name="SLIM_0_TX Format" value="S24_LE" />
+    </path>
+
+    <path name="stereo-mic">
+        <path name="stereo-mic-common" />
+        <ctl name="DEC8 Volume" value="101" />
+        <ctl name="DEC7 Volume" value="83" />
+    </path>
+
+    <path name="stereo-mic-gain-low">
+        <path name="stereo-mic-common" />
+        <ctl name="DEC8 Volume" value="98" />
+        <ctl name="DEC7 Volume" value="80" />
+    </path>
+
+    <path name="stereo-mic-gain-mid">
+        <path name="stereo-mic-common" />
+        <ctl name="DEC8 Volume" value="114" />
+        <ctl name="DEC7 Volume" value="96" />
+    </path>
+
+    <path name="stereo-mic-gain-high">
+        <path name="stereo-mic-common" />
+        <ctl name="DEC8 Volume" value="123" />
+        <ctl name="DEC7 Volume" value="105" />
+    </path>
+
+    <path name="speaker-mono-mic-common">
+        <ctl name="TX7 HPF cut off" value="CF_NEG_3DB_4HZ" />
+        <path name="dmic1" />
+    </path>
+
+    <path name="speaker-mono-mic">
+        <path name="speaker-mono-mic-common" />
+        <ctl name="DEC7 Volume" value="101" />
+    </path>
+
+    <path name="speaker-mono-mic-gain-low">
+        <path name="speaker-mono-mic-common" />
+        <ctl name="DEC7 Volume" value="98" />
+    </path>
+
+    <path name="speaker-mono-mic-gain-mid">
+        <path name="speaker-mono-mic-common" />
+        <ctl name="DEC7 Volume" value="114" />
+    </path>
+
+    <path name="speaker-mono-mic-gain-high">
+        <path name="speaker-mono-mic-common" />
+        <ctl name="DEC7 Volume" value="123" />
+    </path>
+
+    <path name="speaker-mic-sbc">
+        <path name="adc5" />
+        <ctl name="ADC5 Volume" value="12" />
+    </path>
+
+    <path name="speaker-protected">
+        <path name="speaker" />
+    </path>
+
+    <path name="voice-speaker-protected">
+        <ctl name="AIF4_VI Mixer SPKR_VI_1" value="1" />
+        <ctl name="SLIM_4_TX Format" value="PACKED_16B" />
+        <path name="wsa-speaker-mono" />
+        <ctl name="VI_FEED_TX Channels" value="One" />
+        <ctl name="SLIM0_RX_VI_FB_LCH_MUX"  value="SLIM4_TX" />
+    </path>
+
+    <path name="vi-feedback">
+    </path>
+
+   <path name="speaker-protected-vbat">
+       <path name="speaker-protected" />
+       <ctl name="RX INT7 VBAT SPKRL VBAT Enable" value="1" />
+       <ctl name="RX INT8 VBAT SPKRR VBAT Enable" value="1" />
+   </path>
+
+   <path name="handset">
+        <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM_0_RX Channels" value="One" />
+        <ctl name="RX INT0_1 MIX1 INP0" value="RX0" />
+        <ctl name="RX INT0 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="EAR PA Gain" value="G_6_DB" />
+        <ctl name="RX0 Digital Volume" value="84" />
+        <ctl name="MSM_Ear_Enable_States" value="Enable"/>
+    </path>
+
+    <path name="handset-mic">
+        <path name="dmic1" />
+        <path name="dmic1-adj-gain" />
+    </path>
+
+    <path name="handset-mic-asr">
+        <path name="dmic1" />
+        <path name="dmic1-adj-gain" />
+    </path>
+
+    <path name="handset-mic-db">
+        <path name="adc6" />
+    </path>
+
+    <path name="handset-mic-cdp">
+        <path name="adc1" />
+        <ctl name="ADC1 Volume" value="12" />
+    </path>
+
+    <path name="handset-mic-sbc">
+        <path name="adc5" />
+        <ctl name="ADC5 Volume" value="12" />
+    </path>
+
+    <path name="handset-secondary-mic">
+        <path name="dmic4" />
+    </path>
+
+    <path name="anc-handset">
+        <ctl name="ANC Function" value="ON" />
+        <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM_0_RX Channels" value="One" />
+        <ctl name="RX INT0_1 MIX1 INP0" value="RX0" />
+        <ctl name="RX INT0 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="RX0 Digital Volume" value="81" />
+        <ctl name="ANC Slot" value="6" />
+        <ctl name="ADC MUX10" value="DMIC" />
+        <ctl name="DMIC MUX10" value="DMIC3" />
+        <ctl name="ANC0 FB MUX" value="ANC_IN_EAR" />
+        <ctl name="ANC EAR Enable Switch" value="1" />
+    </path>
+
+    <path name="headphones">
+        <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM RX1 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM_0_RX Channels" value="Two" />
+        <ctl name="RX INT1_1 MIX1 INP0" value="RX0" />
+        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX INT1 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="RX INT2 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="COMP1 Switch" value="1" />
+        <ctl name="COMP2 Switch" value="1" />
+    </path>
+
+    <path name="headphones-44.1">
+        <ctl name="SLIM RX3 MUX" value="AIF3_PB" />
+        <ctl name="SLIM RX4 MUX" value="AIF3_PB" />
+        <ctl name="SLIM_5_RX Channels" value="Two" />
+        <ctl name="SLIM_5_RX SampleRate" value="KHZ_44P1" />
+        <ctl name="RX INT1_1 MIX1 INP0" value="RX3" />
+        <ctl name="RX INT2_1 MIX1 INP1" value="RX4" />
+        <ctl name="RX INT1 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="RX INT2 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="SPL SRC0 MUX" value="SRC_IN_HPHL" />
+        <ctl name="SPL SRC1 MUX" value="SRC_IN_HPHR" />
+        <ctl name="RX INT1 SPLINE MIX HPHL Switch" value="1" />
+        <ctl name="RX INT2 SPLINE MIX HPHR Switch" value="1" />
+        <ctl name="COMP1 Switch" value="1" />
+        <ctl name="COMP2 Switch" value="1" />
+    </path>
+
+    <path name="headphones-regulation">
+        <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM RX1 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM_0_RX Channels" value="Two" />
+        <ctl name="RX INT1_1 MIX1 INP0" value="RX0" />
+        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX INT1 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="RX INT2 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="COMP1 Switch" value="1" />
+        <ctl name="COMP2 Switch" value="1" />
+        <ctl name="RX1 Digital Volume" value="76" />
+        <ctl name="RX2 Digital Volume" value="76" />
+    </path>
+
+    <path name="headphones-hpf">
+        <ctl name="RX INT1_1 HPF cut off" value="CF_NEG_3DB_150HZ" />
+        <ctl name="RX INT2_1 HPF cut off" value="CF_NEG_3DB_150HZ" />
+    </path>
+
+    <path name="headset-mic">
+        <path name="adc2" />
+        <ctl name="DEC0 Volume" value="99" />
+        <ctl name="ADC2 Volume" value="8" />
+    </path>
+
+    <path name="headset-mic-asr">
+        <path name="headset-mic" />
+    </path>
+
+    <path name="headset-mic-rec-common">
+        <ctl name="TX0 HPF cut off" value="CF_NEG_3DB_4HZ" />
+        <path name="adc2" />
+        <!--80 % of 124 (rounded) register: 0x241-->
+        <ctl name="DEC0 Volume" value="84" />
+    </path>
+
+    <path name="headset-mic-rec">
+        <path name="headset-mic-rec-common" />
+        <ctl name="ADC2 Volume" value="13" />
+    </path>
+
+    <path name="headset-mic-rec-gain-high">
+        <path name="headset-mic-rec-common" />
+        <ctl name="ADC2 Volume" value="18" />
+    </path>
+
+    <path name="headset-mic-rec-gain-mid">
+        <path name="headset-mic-rec-common" />
+        <ctl name="ADC2 Volume" value="17" />
+    </path>
+
+    <path name="headset-mic-rec-gain-low">
+        <path name="headset-mic-rec-common" />
+        <ctl name="ADC2 Volume" value="5" />
+    </path>
+
+    <path name="voice-handset">
+        <path name="handset" />
+    </path>
+
+    <path name="voice-handset-hac">
+        <path name="handset" />
+    </path>
+
+    <path name="voice-handset-eq1">
+        <path name="handset" />
+    </path>
+
+    <path name="voice-handset-tmus">
+        <path name="handset" />
+    </path>
+
+    <path name="vbat-voice-speaker">
+        <path name="vbat-speaker-mono" />
+    </path>
+
+    <path name="wsa-voice-speaker">
+        <path name="wsa-speaker-mono" />
+    </path>
+
+    <path name="voice-speaker">
+        <path name="speaker" />
+        <ctl name="RX7 Digital Volume" value="0" />
+    </path>
+
+    <path name="voice-speaker-mic">
+        <path name="speaker-mic" />
+    </path>
+
+    <path name="voice-headphones">
+        <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM RX1 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM_0_RX Channels" value="Two" />
+        <ctl name="RX INT1_1 MIX1 INP0" value="RX0" />
+        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX INT1 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="RX INT2 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="RX1 Digital Volume" value="76" />
+        <ctl name="RX2 Digital Volume" value="76" />
+    </path>
+
+    <path name="voice-headphones-eq1">
+        <path name="voice-headphones" />
+    </path>
+
+    <path name="voice-headset-mic">
+        <path name="headset-mic" />
+    </path>
+
+    <path name="voip-speaker-mic">
+        <path name="voice-speaker-mic" />
+    </path>
+
+    <path name="voip-headset-mic">
+        <path name="voice-headset-mic" />
+    </path>
+
+    <path name="speaker-and-headphones">
+        <path name="speaker" />
+        <ctl name="RX INT1_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX INT1 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="RX INT2 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="RX1 Digital Volume" value="55" />
+        <ctl name="RX2 Digital Volume" value="55" />
+        <path name="headphones-hpf" />
+        <ctl name="Set Custom Stereo" value="Mix" />
+    </path>
+
+    <path name="ringtone-speaker-and-headphones">
+        <path name="ringtone-speaker" />
+        <ctl name="RX INT1_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX INT1 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="RX INT2 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="RX1 Digital Volume" value="55" />
+        <ctl name="RX2 Digital Volume" value="55" />
+        <path name="headphones-hpf" />
+    </path>
+
+    <path name="ringtone-speaker-mono-and-headphones">
+        <path name="ringtone-speaker-mono" />
+        <ctl name="RX INT1_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX INT1 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="RX INT2 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="RX1 Digital Volume" value="55" />
+        <ctl name="RX2 Digital Volume" value="55" />
+        <path name="headphones-hpf" />
+    </path>
+
+    <path name="usb-headphones">
+    </path>
+
+    <path name="afe-proxy">
+    </path>
+
+    <path name="transmission-fm">
+    </path>
+
+    <path name="anc-headphones">
+        <ctl name="ANC Function" value="ON" />
+        <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM RX1 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM_0_RX Channels" value="Two" />
+        <ctl name="RX INT1_1 MIX1 INP0" value="RX0" />
+        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX INT1 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="RX INT2 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="HPHL Volume" value="14" />
+        <ctl name="HPHR Volume" value="14" />
+        <ctl name="RX1 Digital Volume" value="81" />
+        <ctl name="RX2 Digital Volume" value="81" />
+        <ctl name="ANC Slot" value="0" />
+        <ctl name="ANC0 FB MUX" value="ANC_IN_HPHL" />
+        <ctl name="ANC1 FB MUX" value="ANC_IN_HPHR" />
+        <ctl name="RX1 Digital Volume" value="60" />
+        <ctl name="RX2 Digital Volume" value="60" />
+        <ctl name="ADC MUX10" value="AMIC" />
+        <ctl name="AMIC MUX10" value="ADC3" />
+        <ctl name="ADC MUX12" value="AMIC" />
+        <ctl name="AMIC MUX12" value="ADC4" />
+        <ctl name="ANC HPHL Enable Switch" value="1" />
+        <ctl name="ANC HPHR Enable Switch" value="1" />
+        <ctl name="ADC3 Volume" value="8" />
+        <ctl name="ADC4 Volume" value="8" />
+    </path>
+
+    <path name="speaker-and-anc-headphones">
+        <path name="anc-headphones" />
+        <ctl name="RX INT7_1 MIX1 INP0" value="RX0" />
+        <ctl name="COMP7 Switch" value="1" />
+    </path>
+
+    <path name="anc-fb-headphones">
+        <path name="anc-headphones" />
+        <ctl name="ANC Slot" value="1" />
+    </path>
+
+    <path name="speaker-and-anc-fb-headphones">
+        <path name="anc-fb-headphones" />
+        <ctl name="RX INT7_1 MIX1 INP0" value="RX0" />
+        <ctl name="COMP7 Switch" value="1" />
+    </path>
+
+    <path name="voice-anc-headphones">
+        <ctl name="ANC Function" value="ON" />
+        <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM RX1 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM_0_RX Channels" value="Two" />
+        <ctl name="RX INT1_1 MIX1 INP0" value="RX0" />
+        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
+        <ctl name="IIR0 Enable Band1" value="1" />
+        <ctl name="IIR0 Enable Band2" value="1" />
+        <ctl name="IIR0 Enable Band3" value="1" />
+        <ctl name="IIR0 Enable Band4" value="1" />
+        <ctl name="IIR0 Enable Band5" value="1" />
+        <ctl name="IIR0 INP0 Volume" value="54" />
+        <ctl name="RX INT1 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="RX INT2 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="HPHL Volume" value="14" />
+        <ctl name="HPHR Volume" value="14" />
+        <ctl name="RX1 Digital Volume" value="81" />
+        <ctl name="RX2 Digital Volume" value="81" />
+        <ctl name="ANC Slot" value="0" />
+        <ctl name="ANC0 FB MUX" value="ANC_IN_HPHL" />
+        <ctl name="ANC1 FB MUX" value="ANC_IN_HPHR" />
+        <ctl name="ADC MUX10" value="AMIC" />
+        <ctl name="AMIC MUX10" value="ADC3" />
+        <ctl name="ADC MUX12" value="AMIC" />
+        <ctl name="AMIC MUX12" value="ADC4" />
+        <ctl name="ANC HPHL Enable Switch" value="1" />
+        <ctl name="ANC HPHR Enable Switch" value="1" />
+        <ctl name="ADC3 Volume" value="8" />
+        <ctl name="ADC4 Volume" value="8" />
+    </path>
+
+    <path name="voice-anc-fb-headphones">
+        <ctl name="ANC Function" value="ON" />
+        <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM RX1 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM_0_RX Channels" value="Two" />
+        <ctl name="RX INT1_1 MIX1 INP0" value="RX0" />
+        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
+        <ctl name="IIR0 Enable Band1" value="1" />
+        <ctl name="IIR0 Enable Band2" value="1" />
+        <ctl name="IIR0 Enable Band3" value="1" />
+        <ctl name="IIR0 Enable Band4" value="1" />
+        <ctl name="IIR0 Enable Band5" value="1" />
+        <ctl name="IIR0 INP0 Volume" value="62" />
+        <ctl name="RX INT1 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="RX INT2 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="HPHL Volume" value="14" />
+        <ctl name="HPHR Volume" value="14" />
+        <ctl name="RX1 Digital Volume" value="81" />
+        <ctl name="RX2 Digital Volume" value="81" />
+        <ctl name="ANC Slot" value="1" />
+        <ctl name="ANC0 FB MUX" value="ANC_IN_HPHL" />
+        <ctl name="ANC1 FB MUX" value="ANC_IN_HPHR" />
+        <ctl name="ADC MUX10" value="AMIC" />
+        <ctl name="AMIC MUX10" value="ADC3" />
+        <ctl name="ADC MUX12" value="AMIC" />
+        <ctl name="AMIC MUX12" value="ADC4" />
+        <ctl name="ANC HPHL Enable Switch" value="1" />
+        <ctl name="ANC HPHR Enable Switch" value="1" />
+        <ctl name="ADC3 Volume" value="8" />
+        <ctl name="ADC4 Volume" value="8" />
+    </path>
+
+
+    <path name="hdmi">
+    </path>
+
+    <path name="speaker-and-usb-headphones">
+        <path name="wsa-speaker" />
+        <path name="usb-headphones" />
+    </path>
+
+    <path name="speaker-and-hdmi">
+        <path name="wsa-speaker" />
+        <path name="hdmi" />
+    </path>
+
+    <path name="voice-rec-mic">
+        <path name="handset-mic" />
+    </path>
+
+    <path name="camcorder-mic-common">
+        <ctl name="AIF1_CAP Mixer SLIM TX7" value="1" />
+        <ctl name="AIF1_CAP Mixer SLIM TX8" value="1" />
+        <ctl name="SLIM_0_TX Channels" value="Two" />
+        <ctl name="TX8 HPF cut off" value="CF_NEG_3DB_4HZ" />
+        <ctl name="TX7 HPF cut off" value="CF_NEG_3DB_4HZ" />
+        <ctl name="SLIM TX7 MUX" value="DEC7" />
+        <ctl name="SLIM TX8 MUX" value="DEC8" />
+        <ctl name="ADC MUX8" value="DMIC" />
+        <ctl name="DMIC MUX8" value="DMIC0" />
+        <ctl name="ADC MUX7" value="DMIC" />
+        <ctl name="DMIC MUX7" value="DMIC3" />
+        <ctl name="SLIM_0_TX Format" value="S24_LE" />
+    </path>
+
+    <path name="camcorder-mic">
+        <path name="handset-mic" />
+        <ctl name="SLIM_0_TX Format" value="S16_LE" />
+        <ctl name="DEC8 Volume" value="125" />
+        <ctl name="DEC7 Volume" value="107" />
+    </path>
+
+    <path name="camcorder-mic-gain-low">
+        <path name="camcorder-mic-common" />
+        <ctl name="DEC8 Volume" value="98" />
+        <ctl name="DEC7 Volume" value="80" />
+    </path>
+
+    <path name="camcorder-mic-gain-mid">
+        <path name="camcorder-mic-common" />
+        <ctl name="DEC8 Volume" value="114" />
+        <ctl name="DEC7 Volume" value="96" />
+    </path>
+
+    <path name="camcorder-mic-gain-high">
+        <path name="camcorder-mic-common" />
+        <ctl name="DEC8 Volume" value="123" />
+        <ctl name="DEC7 Volume" value="105" />
+    </path>
+
+    <path name="hdmi-tx">
+        <path name="handset-mic" />
+    </path>
+
+    <path name="bt-sco-headset">
+    </path>
+
+    <path name="bt-sco-mic">
+    </path>
+
+    <path name="bt-sco-carkit-mic">
+    </path>
+
+    <path name="bt-sco-dsp-mic">
+    </path>
+
+    <path name="bt-sco-headset-wb">
+    </path>
+
+    <path name="bt-sco-mic-wb">
+    </path>
+
+    <path name="bt-sco-carkit-mic-wb">
+    </path>
+
+    <path name="bt-sco-dsp-mic-wb">
+    </path>
+
+    <path name="voip-bt-sco-mic">
+        <path name="bt-sco-mic" />
+    </path>
+
+    <path name="voip-bt-sco-dsp-mic">
+        <path name="bt-sco-dsp-mic" />
+    </path>
+
+    <path name="voip-bt-sco-mic-wb">
+        <path name="bt-sco-mic-wb" />
+    </path>
+
+    <path name="voip-bt-sco-carkit-mic-wb">
+        <path name="bt-sco-carkit-mic-wb" />
+    </path>
+
+    <path name="voip-bt-sco-dsp-mic-wb">
+        <path name="bt-sco-dsp-mic-wb" />
+    </path>
+
+    <path name="usb-headset-mic">
+    </path>
+
+    <path name="capture-fm">
+    </path>
+
+    <path name="capture-ahc">
+        <ctl name="AIF1_CAP Mixer SLIM TX1" value="1" />
+        <ctl name="AIF1_CAP Mixer SLIM TX6" value="1" />
+        <!-- SLIM TX6 records for right channel -->
+        <ctl name="SLIM TX6 MUX" value="DEC6" />
+        <ctl name="LDO_H Enable" value="1"/>
+        <!-- ADC1 measures over resistance -->
+        <ctl name="ADC MUX6" value="AMIC" />
+        <ctl name="AMIC MUX6" value="ADC1" />
+        <!-- 67 % of 124 (range 0 - 124) Register: 0x229 -->
+        <ctl name="DEC6 Volume" value="83" />
+        <!-- 84 % of 19 (range 0 - 19) Register: 0x167 -->
+        <ctl name="ADC1 Volume" value="12" />
+        <!-- SLIM TX1 records for left channel -->
+        <ctl name="SLIM TX1 MUX" value="DEC1" />
+        <!-- ADC4 measures over headset -->
+        <ctl name="ADC MUX1" value="AMIC" />
+        <ctl name="AMIC MUX1" value="ADC4" />
+        <!-- 67 % of 124 (range 0 - 124) Register: 0x221 -->
+        <ctl name="DEC1 Volume" value="83" />
+        <!-- 47 % of 19 (rounded) register: 0x169 -->
+        <ctl name="ADC4 Volume" value="6" />
+        <ctl name="SLIM_0_TX Channels" value="Two" />
+    </path>
+
+    <path name="aanc-handset-mic">
+        <ctl name="AIF1_CAP Mixer SLIM TX6" value="1" />
+        <ctl name="AIF1_CAP Mixer SLIM TX8" value="1" />
+        <ctl name="AIF1_CAP Mixer SLIM TX9" value="1" />
+        <ctl name="SLIM_0_TX Channels" value="Three" />
+        <ctl name="AANC_SLIM_0_RX MUX" value="SLIMBUS_0_TX" />
+        <ctl name="SLIM TX6 MUX" value="DEC6" />
+        <ctl name="ADC MUX6" value="DMIC" />
+        <ctl name="DMIC MUX6" value="DMIC0" />
+        <ctl name="SLIM TX8 MUX" value="DEC8" />
+        <ctl name="ADC MUX8" value="DMIC" />
+        <ctl name="DMIC MUX8" value="DMIC3" />
+        <ctl name="SLIM TX9 MUX" value="DEC7" />
+        <ctl name="ADC MUX7" value="DMIC" />
+        <ctl name="DMIC MUX7" value="DMIC2" />
+        <ctl name="IIR0 INP0 MUX" value="DEC6" />
+    </path>
+
+    <path name="aanc-fluence-dmic-handset">
+        <path name="aanc-handset-mic" />
+    </path>
+
+    <!-- Dual MIC devices -->
+    <path name="handset-dmic-endfire">
+        <ctl name="AIF1_CAP Mixer SLIM TX7" value="1" />
+        <ctl name="AIF1_CAP Mixer SLIM TX8" value="1" />
+        <ctl name="SLIM TX7 MUX" value="DEC7" />
+        <ctl name="ADC MUX7" value="DMIC" />
+        <ctl name="DMIC MUX7" value="DMIC0" />
+        <ctl name="SLIM TX8 MUX" value="DEC8" />
+        <ctl name="ADC MUX8" value="DMIC" />
+        <ctl name="DMIC MUX8" value="DMIC3" />
+        <ctl name="SLIM_0_TX Channels" value="Two" />
+        <path name="dmic1-adj-gain" />
+        <path name="dmic2-adj-gain" />
+    </path>
+
+    <path name="speaker-dmic-endfire">
+        <ctl name="AIF1_CAP Mixer SLIM TX7" value="1" />
+        <ctl name="AIF1_CAP Mixer SLIM TX8" value="1" />
+        <ctl name="SLIM TX7 MUX" value="DEC7" />
+        <ctl name="ADC MUX7" value="DMIC" />
+        <ctl name="DMIC MUX7" value="DMIC2" />
+        <ctl name="SLIM TX8 MUX" value="DEC8" />
+        <ctl name="ADC MUX8" value="DMIC" />
+        <ctl name="DMIC MUX8" value="DMIC3" />
+        <ctl name="SLIM_0_TX Channels" value="Two" />
+    </path>
+
+    <path name="dmic-endfire">
+        <path name="handset-dmic-endfire" />
+        <ctl name="IIR0 INP0 MUX" value="DEC7" />
+    </path>
+
+    <path name="binaural-mic-disable">
+        <ctl name="AIF1_CAP Mixer SLIM TX7" value="0" />
+        <ctl name="AIF1_CAP Mixer SLIM TX8" value="0" />
+        <ctl name="SLIM TX7 MUX" value="ZERO" />
+        <ctl name="ADC MUX7" value="ZERO" />
+        <ctl name="DMIC MUX7" value="ZERO" />
+        <ctl name="DEC7 Volume" value="84" />
+        <ctl name="SLIM TX8 MUX" value="ZERO" />
+        <ctl name="ADC MUX8" value="ZERO" />
+        <ctl name="DMIC MUX8" value="ZERO" />
+        <ctl name="DEC8 Volume" value="84" />
+        <ctl name="SLIM_0_TX Channels" value="One" />
+        <!-- ST L -->
+        <ctl name="RX INT1 MIX2 INP" value="ZERO" />
+        <ctl name="IIR0 Enable Band1" value="0" />
+        <ctl name="IIR0 Enable Band2" value="0" />
+        <ctl name="IIR0 Enable Band3" value="0" />
+        <ctl name="IIR0 Enable Band4" value="0" />
+        <ctl name="IIR0 Enable Band5" value="0" />
+        <ctl name="IIR0 INP0 MUX" value="ZERO" />
+
+        <!-- ST R -->
+        <ctl name="RX INT2 MIX2 INP" value="ZERO" />
+        <ctl name="IIR1 Enable Band1" value="0" />
+        <ctl name="IIR1 Enable Band2" value="0" />
+        <ctl name="IIR1 Enable Band3" value="0" />
+        <ctl name="IIR1 Enable Band4" value="0" />
+        <ctl name="IIR1 Enable Band5" value="0" />
+        <ctl name="IIR1 INP0 MUX" value="ZERO" />
+
+        <ctl name="IIR0 INP0 Volume" value="54" />
+        <ctl name="IIR1 INP0 Volume" value="54" />
+    </path>
+
+    <path name="binaural-mic-monitoring">
+        <!-- ST L -->
+        <ctl name="RX INT1 MIX2 INP" value="SRC0" />
+        <path name="binaural-monitoring-iir0" />
+        <ctl name="IIR0 INP0 MUX" value="DEC7" />
+
+        <!-- ST R -->
+        <ctl name="RX INT2 MIX2 INP" value="SRC1" />
+        <path name="binaural-monitoring-iir1" />
+        <ctl name="IIR1 INP0 MUX" value="DEC8" />
+
+        <!-- RX -->
+        <ctl name="RX INT1 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="RX INT2 DEM MUX" value="CLSH_DSM_OUT" />
+        <!--75 % of 20 register: 0x1AE-->
+        <ctl name="HPHL Volume" value="20" />
+        <!--75 % of 20 register: 0x1B4-->
+        <ctl name="HPHR Volume" value="20" />
+        <!--66 % of 124 (rounded) register: 0x2B7-->
+        <ctl name="RX1 Digital Volume" value="75" />
+        <!--66 % of 124 (rounded) register: 0x2BF-->
+        <ctl name="RX2 Digital Volume" value="75" />
+    </path>
+
+    <path name="binaural-mic-common">
+        <ctl name="COMP1 Switch" value="0" />
+        <ctl name="COMP2 Switch" value="0" />
+
+        <!-- TX  -->
+        <ctl name="AIF1_CAP Mixer SLIM TX7" value="1" />
+        <ctl name="AIF1_CAP Mixer SLIM TX8" value="1" />
+        <ctl name="TX8 HPF cut off" value="CF_NEG_3DB_4HZ" />
+        <ctl name="TX7 HPF cut off" value="CF_NEG_3DB_4HZ" />
+        <ctl name="SLIM TX7 MUX" value="DEC7" />
+        <ctl name="ADC MUX7" value="AMIC" />
+        <ctl name="AMIC MUX7" value="ADC3" />
+        <ctl name="DEC7 Volume" value="84" />
+        <ctl name="SLIM TX8 MUX" value="DEC8" />
+        <ctl name="ADC MUX8" value="AMIC" />
+        <ctl name="AMIC MUX8" value="ADC2" />
+        <ctl name="DEC8 Volume" value="84" />
+        <ctl name="SLIM_0_TX Channels" value="Two" />
+        <path name="binaural-mic-monitoring" />
+        <ctl name="SLIM_0_TX Format" value="S24_LE" />
+    </path>
+
+    <path name="binaural-mic">
+        <!-- 120dBSPLpeak & -33dBV/Pa so mic gain 10.5dB so ADCx VOL = 7 -->
+        <ctl name="ADC3 Volume" value="6" />
+        <ctl name="ADC2 Volume" value="6" />
+        <ctl name="IIR0 INP0 Volume" value="80" />
+        <ctl name="IIR1 INP0 Volume" value="80" />
+        <path name="binaural-mic-common" />
+    </path>
+
+    <path name="binaural-mic-gain-high">
+        <!-- 93dBSPLpeak & -33dBV/Pa so mic gain 28.5dB so ADCx VOL = 19 -->
+        <ctl name="ADC3 Volume" value="18" />
+        <ctl name="ADC2 Volume" value="18" />
+        <ctl name="IIR0 INP0 Volume" value="62" />
+        <ctl name="IIR1 INP0 Volume" value="62" />
+        <path name="binaural-mic-common" />
+    </path>
+
+    <path name="binaural-mic-gain-mid">
+        <!-- 112dBSPLpeak & -33dBV/Pa so mic gain 18dB so ADCx VOL = 12 -->
+        <ctl name="ADC3 Volume" value="17" />
+        <ctl name="ADC2 Volume" value="17" />
+        <ctl name="IIR0 INP0 Volume" value="63" />
+        <ctl name="IIR1 INP0 Volume" value="63" />
+        <path name="binaural-mic-common" />
+    </path>
+
+    <path name="binaural-mic-gain-low">
+        <!-- 120dBSPLpeak & -33dBV/Pa so mic gain 10.5dB so ADCx VOL = 7 -->
+        <ctl name="ADC3 Volume" value="5" />
+        <ctl name="ADC2 Volume" value="5" />
+        <ctl name="IIR0 INP0 Volume" value="81" />
+        <ctl name="IIR1 INP0 Volume" value="81" />
+        <path name="binaural-mic-common" />
+    </path>
+
+    <path name="binaural2-mic">
+        <!-- 120dBSPLpeak & -33dBV/Pa so mic gain 10.5dB so ADCx VOL = 7 -->
+        <ctl name="ADC3 Volume" value="6" />
+        <ctl name="ADC2 Volume" value="6" />
+        <ctl name="IIR0 INP0 Volume" value="80" />
+        <ctl name="IIR1 INP0 Volume" value="80" />
+        <path name="binaural-mic-common" />
+    </path>
+
+    <path name="binaural2-mic-gain-high">
+        <!-- 93dBSPLpeak & -33dBV/Pa so mic gain 28.5dB so ADCx VOL = 19 -->
+        <ctl name="ADC3 Volume" value="18" />
+        <ctl name="ADC2 Volume" value="18" />
+        <ctl name="IIR0 INP0 Volume" value="62" />
+        <ctl name="IIR1 INP0 Volume" value="62" />
+        <path name="binaural-mic-common" />
+    </path>
+
+    <path name="binaural2-mic-gain-mid">
+        <!-- 112dBSPLpeak & -33dBV/Pa so mic gain 18dB so ADCx VOL = 12 -->
+        <ctl name="ADC3 Volume" value="17" />
+        <ctl name="ADC2 Volume" value="17" />
+        <ctl name="IIR0 INP0 Volume" value="63" />
+        <ctl name="IIR1 INP0 Volume" value="63" />
+        <path name="binaural-mic-common" />
+    </path>
+
+    <path name="binaural2-mic-gain-low">
+        <!-- 120dBSPLpeak & -33dBV/Pa so mic gain 10.5dB so ADCx VOL = 7 -->
+        <ctl name="ADC3 Volume" value="5" />
+        <ctl name="ADC2 Volume" value="5" />
+        <ctl name="IIR0 INP0 Volume" value="81" />
+        <ctl name="IIR1 INP0 Volume" value="81" />
+        <path name="binaural-mic-common" />
+    </path>
+
+    <path name="handset-stereo-dmic-ef">
+        <path name="handset-dmic-endfire" />
+    </path>
+
+    <path name="speaker-stereo-dmic-ef">
+        <path name="speaker-dmic-endfire" />
+    </path>
+
+    <path name="voice-dmic-ef-tmus">
+        <path name="dmic-endfire" />
+    </path>
+
+    <path name="voice-dmic-ef">
+        <path name="dmic-endfire" />
+    </path>
+
+    <path name="voice-speaker-dmic-ef">
+        <path name="speaker-dmic-endfire" />
+    </path>
+
+    <path name="voice-rec-dmic-ef">
+        <path name="dmic-endfire" />
+    </path>
+
+    <path name="voice-rec-dmic-ef-fluence">
+        <path name="dmic-endfire" />
+    </path>
+
+    <path name="voip-dmic-ef">
+        <path name="voice-dmic-ef" />
+    </path>
+
+    <path name="speaker-dmic-broadside">
+        <ctl name="AIF1_CAP Mixer SLIM TX7" value="1" />
+        <ctl name="AIF1_CAP Mixer SLIM TX8" value="1" />
+        <ctl name="SLIM_0_TX Channels" value="Two" />
+        <ctl name="SLIM TX7 MUX" value="DEC7" />
+        <ctl name="ADC MUX7" value="DMIC" />
+        <ctl name="DMIC MUX7" value="DMIC0" />
+        <ctl name="SLIM TX8 MUX" value="DEC8" />
+        <ctl name="ADC MUX8" value="DMIC" />
+        <ctl name="DMIC MUX8" value="DMIC1" />
+    </path>
+
+    <path name="external-stereo-mic-common">
+        <ctl name="AIF1_CAP Mixer SLIM TX7" value="1" />
+        <ctl name="AIF1_CAP Mixer SLIM TX8" value="1" />
+        <ctl name="TX8 HPF cut off" value="CF_NEG_3DB_4HZ" />
+        <ctl name="TX7 HPF cut off" value="CF_NEG_3DB_4HZ" />
+        <ctl name="SLIM TX7 MUX" value="DEC7" />
+        <ctl name="ADC MUX7" value="AMIC" />
+        <ctl name="AMIC MUX7" value="ADC3" />
+        <ctl name="DEC7 Volume" value="84" />
+        <ctl name="SLIM TX8 MUX" value="DEC8" />
+        <ctl name="ADC MUX8" value="AMIC" />
+        <ctl name="AMIC MUX8" value="ADC2" />
+        <ctl name="DEC8 Volume" value="84" />
+        <ctl name="SLIM_0_TX Channels" value="Two" />
+        <ctl name="SLIM_0_TX Format" value="S24_LE" />
+    </path>
+
+    <path name="external-stereo-mic">
+        <path name="external-stereo-mic-common" />
+        <!-- 120dBSPLpeak & -42dBV/Pa so mic gain 19dB so ADCx VOL = 13 -->
+        <ctl name="ADC3 Volume" value="10" />
+        <ctl name="ADC2 Volume" value="10" />
+    </path>
+
+    <path name="external-stereo-mic-gain-high">
+        <path name="external-stereo-mic-common" />
+        <!-- 93dBSPLpeak & -42dBV/Pa so mic gain 28.5dB so ADCx VOL = 19 -->
+        <ctl name="ADC3 Volume" value="18" />
+        <ctl name="ADC2 Volume" value="18" />
+    </path>
+
+    <path name="external-stereo-mic-gain-mid">
+        <path name="external-stereo-mic-common" />
+        <!-- 112dBSPLpeak & -42dBV/Pa so mic gain 18dB so ADCx VOL = 18 -->
+        <ctl name="ADC3 Volume" value="14" />
+        <ctl name="ADC2 Volume" value="14" />
+    </path>
+
+    <path name="external-stereo-mic-gain-low">
+        <path name="external-stereo-mic-common" />
+        <!-- 120dBSPLpeak & -42dBV/Pa so mic gain 19dB so ADCx VOL = 13 -->
+        <ctl name="ADC3 Volume" value="6" />
+        <ctl name="ADC2 Volume" value="6" />
+    </path>
+
+    <path name="dmic-broadside">
+        <path name="speaker-dmic-broadside" />
+        <ctl name="IIR0 INP0 MUX" value="DEC7" />
+    </path>
+
+    <path name="voice-speaker-dmic-broadside">
+        <path name="dmic-broadside" />
+    </path>
+
+    <!-- Quad MIC devices -->
+    <path name="speaker-qmic">
+        <ctl name="AIF1_CAP Mixer SLIM TX5" value="1" />
+        <ctl name="AIF1_CAP Mixer SLIM TX6" value="1" />
+        <ctl name="AIF1_CAP Mixer SLIM TX7" value="1" />
+        <ctl name="AIF1_CAP Mixer SLIM TX8" value="1" />
+        <ctl name="SLIM_0_TX Channels" value="Four" />
+        <ctl name="SLIM TX5 MUX" value="DEC5" />
+        <ctl name="ADC MUX5" value="DMIC" />
+        <ctl name="DMIC MUX5" value="DMIC0" />
+        <ctl name="SLIM TX6 MUX" value="DEC6" />
+        <ctl name="ADC MUX6" value="DMIC" />
+        <ctl name="DMIC MUX6" value="DMIC2" />
+        <ctl name="SLIM TX7 MUX" value="DEC7" />
+        <ctl name="ADC MUX7" value="DMIC" />
+        <ctl name="DMIC MUX7" value="DMIC1" />
+        <ctl name="SLIM TX8 MUX" value="DEC8" />
+        <ctl name="ADC MUX8" value="DMIC" />
+        <ctl name="DMIC MUX8" value="DMIC3" />
+    </path>
+
+
+    <path name="voice-speaker-qmic">
+        <path name="speaker-qmic" />
+    </path>
+
+    <path name="quad-mic">
+        <path name="speaker-qmic" />
+    </path>
+
+    <!-- TTY devices -->
+
+    <path name="tty-headphones">
+        <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM RX1 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM_0_RX Channels" value="Two" />
+        <ctl name="RX INT1_1 MIX1 INP0" value="RX0" />
+        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX INT1 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="RX INT2 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="COMP1 Switch" value="0" />
+        <ctl name="COMP2 Switch" value="0" />
+        <!--0 % of 20 register: 0x1AE-->
+        <ctl name="HPHL Volume" value="10" />
+        <!--50 % of 20 register: 0x1B4-->
+        <ctl name="HPHR Volume" value="10" />
+        <!--68 % of 124 (rounded) register: 0x2B7-->
+        <ctl name="RX1 Digital Volume" value="84" />
+        <!--68 % of 124 (rounded) register: 0x2BF-->
+        <ctl name="RX2 Digital Volume" value="84" />
+    </path>
+
+    <path name="voice-tty-full-headphones">
+        <ctl name="TTY Mode" value="FULL" />
+        <path name="tty-headphones" />
+    </path>
+
+    <path name="voice-tty-vco-headphones">
+        <ctl name="TTY Mode" value="VCO" />
+        <path name="tty-headphones" />
+    </path>
+
+    <path name="voice-tty-hco-handset">
+        <ctl name="TTY Mode" value="HCO" />
+        <path name="handset" />
+    </path>
+
+    <path name="voice-tty-hco-speaker">
+        <ctl name="TTY Mode" value="HCO" />
+        <path name="voice-speaker" />
+    </path>
+
+    <path name="voice-tty-full-headset-mic">
+        <path name="adc2" />
+        <ctl name="ADC2 Volume" value="12" />
+    </path>
+
+    <path name="voice-tty-hco-headset-mic">
+        <path name="voice-tty-full-headset-mic" />
+    </path>
+
+    <path name="voice-tty-vco-handset-mic">
+        <path name="dmic1" />
+        <path name="dmic1-adj-gain" />
+    </path>
+
+    <path name="incall-music">
+        <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM RX1 MUX" value="AIF_MIX1_PB" />
+    </path>
+
+    <path name="incall-music-bt">
+        <path name="incall-music" />
+    </path>
+
+    <path name="incall-music-bt-wb">
+        <path name="incall-music" />
+    </path>
+
+    <path name="incall-music2">
+        <path name="incall-music" />
+    </path>
+
+    <path name="incall-music2-bt">
+        <path name="incall-music2" />
+    </path>
+
+    <path name="incall-music2-bt-wb">
+        <path name="incall-music2" />
+    </path>
+
+    <path name="listen-handset-mic">
+        <ctl name="MADONOFF Switch" value="1" />
+        <ctl name="MAD Input" value="DMIC0" />
+    </path>
+
+    <path name="set-capture-format-24le">
+        <ctl name="SLIM_0_TX Format" value="S24_LE" />
+    </path>
+
+    <path name="set-capture-format-16le">
+        <ctl name="SLIM_0_TX Format" value="S16_LE" />
+    </path>
+
+    <path name="set-capture-format-default">
+        <path name="set-capture-format-16le" />
+    </path>
+
+    <!-- Added for ADSP testfwk -->
+    <path name="ADSP testfwk">
+        <ctl name="SLIMBUS_DL_HL Switch" value="1" />
+    </path>
+
+    <path name="voice-rx">
+    </path>
+
+    <path name="voice-tx">
+    </path>
+
+    <!-- ********************************************* -->
+    <!--             SOMC DNC devices                  -->
+    <!-- ********************************************* -->
+
+    <path name="anc-initial">
+        <ctl name="RX INT1_1 MIX1 INP0" value="ZERO" />
+        <ctl name="RX INT2_1 MIX1 INP0" value="ZERO" />
+        <ctl name="COMP1 Switch" value="0" />
+        <ctl name="COMP2 Switch" value="0" />
+        <ctl name="HPHL Volume" value="20" />
+        <ctl name="HPHR Volume" value="20" />
+        <ctl name="RX1 Digital Volume" value="84" />
+        <ctl name="RX2 Digital Volume" value="84" />
+    </path>
+
+    <!-- ============================================= -->
+    <!--    common sequence for non call devices       -->
+    <!-- ============================================= -->
+
+    <path name="anc-off">
+        <ctl name="ADC MUX10" value="ZERO" />
+        <ctl name="AMIC MUX10" value="ZERO" />
+        <ctl name="ADC MUX12" value="ZERO" />
+        <ctl name="AMIC MUX12" value="ZERO" />
+        <ctl name="ADC3 Volume" value="10" />
+        <ctl name="ADC2 Volume" value="10" />
+        <ctl name="ANC0 FB MUX" value="ZERO" />
+        <ctl name="ANC1 FB MUX" value="ZERO" />
+        <ctl name="ANC HPHL Enable Switch" value="0" />
+        <ctl name="ANC HPHR Enable Switch" value="0" />
+        <ctl name="ANC Function" value="OFF" />
+    </path>
+
+    <path name="anc-on">
+        <ctl name="ANC Function" value="ON" />
+        <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM RX1 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM_0_RX Channels" value="Two" />
+        <ctl name="RX INT1_1 MIX1 INP0" value="RX0" />
+        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX INT1 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="RX INT2 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="COMP1 Switch" value="0" />
+        <ctl name="COMP2 Switch" value="0" />
+        <ctl name="HPHL Volume" value="20" />
+        <ctl name="HPHR Volume" value="20" />
+        <ctl name="RX1 Digital Volume" value="84" />
+        <ctl name="RX2 Digital Volume" value="84" />
+        <ctl name="ADC3 Volume" value="10" />
+        <ctl name="ADC2 Volume" value="10" />
+        <ctl name="ANC0 FB MUX" value="ANC_IN_HPHL" />
+        <ctl name="ANC1 FB MUX" value="ANC_IN_HPHR" />
+        <ctl name="ANC HPHL Enable Switch" value="1" />
+        <ctl name="ANC HPHR Enable Switch" value="1" />
+    </path>
+
+    <path name="anc-on-regulation">
+        <ctl name="ANC Function" value="ON" />
+        <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM RX1 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM_0_RX Channels" value="Two" />
+        <ctl name="RX INT1_1 MIX1 INP0" value="RX0" />
+        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX INT1 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="RX INT2 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="COMP1 Switch" value="0" />
+        <ctl name="COMP2 Switch" value="0" />
+        <ctl name="HPHL Volume" value="20" />
+        <ctl name="HPHR Volume" value="20" />
+        <ctl name="RX1 Digital Volume" value="77" />
+        <ctl name="RX2 Digital Volume" value="77" />
+        <ctl name="ADC3 Volume" value="10" />
+        <ctl name="ADC2 Volume" value="10" />
+        <ctl name="ANC0 FB MUX" value="ANC_IN_HPHL" />
+        <ctl name="ANC1 FB MUX" value="ANC_IN_HPHR" />
+        <ctl name="ANC HPHL Enable Switch" value="1" />
+        <ctl name="ANC HPHR Enable Switch" value="1" />
+    </path>
+
+    <path name="anc2-off">
+        <path name="anc-off" />
+    </path>
+
+    <path name="anc2-on">
+        <ctl name="ANC Function" value="ON" />
+        <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM RX1 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM_0_RX Channels" value="Two" />
+        <ctl name="RX INT1_1 MIX1 INP0" value="RX0" />
+        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX INT1 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="RX INT2 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="COMP1 Switch" value="0" />
+        <ctl name="COMP2 Switch" value="0" />
+        <ctl name="HPHL Volume" value="20" />
+        <ctl name="HPHR Volume" value="20" />
+        <ctl name="RX1 Digital Volume" value="84" />
+        <ctl name="RX2 Digital Volume" value="84" />
+        <ctl name="ADC3 Volume" value="10" />
+        <ctl name="ADC2 Volume" value="10" />
+        <ctl name="ANC0 FB MUX" value="ANC_IN_HPHL" />
+        <ctl name="ANC1 FB MUX" value="ANC_IN_HPHR" />
+        <ctl name="ANC HPHL Enable Switch" value="1" />
+        <ctl name="ANC HPHR Enable Switch" value="1" />
+    </path>
+
+    <path name="anc2-on-regulation">
+        <ctl name="ANC Function" value="ON" />
+        <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM RX1 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM_0_RX Channels" value="Two" />
+        <ctl name="RX INT1_1 MIX1 INP0" value="RX0" />
+        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX INT1 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="RX INT2 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="COMP1 Switch" value="0" />
+        <ctl name="COMP2 Switch" value="0" />
+        <ctl name="HPHL Volume" value="20" />
+        <ctl name="HPHR Volume" value="20" />
+        <ctl name="RX1 Digital Volume" value="77" />
+        <ctl name="RX2 Digital Volume" value="77" />
+        <ctl name="ADC3 Volume" value="10" />
+        <ctl name="ADC2 Volume" value="10" />
+        <ctl name="ANC0 FB MUX" value="ANC_IN_HPHL" />
+        <ctl name="ANC1 FB MUX" value="ANC_IN_HPHR" />
+        <ctl name="ANC HPHL Enable Switch" value="1" />
+        <ctl name="ANC HPHR Enable Switch" value="1" />
+    </path>
+
+    <!-- ========  for deivce  ======== -->
+
+    <path name="anc-off-headphone">
+        <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM RX1 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM_0_RX Channels" value="Two" />
+        <ctl name="RX INT1_1 MIX1 INP0" value="RX0" />
+        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX INT1 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="RX INT2 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="COMP1 Switch" value="0" />
+        <ctl name="COMP2 Switch" value="0" />
+        <ctl name="HPHL Volume" value="20" />
+        <ctl name="HPHR Volume" value="20" />
+        <ctl name="RX1 Digital Volume" value="84" />
+        <ctl name="RX2 Digital Volume" value="84" />
+    </path>
+
+    <path name="anc-off-headphone-regulation">
+        <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM RX1 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM_0_RX Channels" value="Two" />
+        <ctl name="RX INT1_1 MIX1 INP0" value="RX0" />
+        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX INT1 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="RX INT2 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="COMP1 Switch" value="0" />
+        <ctl name="COMP2 Switch" value="0" />
+        <ctl name="HPHL Volume" value="20" />
+        <ctl name="HPHR Volume" value="20" />
+        <ctl name="RX1 Digital Volume" value="77" />
+        <ctl name="RX2 Digital Volume" value="77" />
+    </path>
+
+    <path name="anc-off-headphone-combo">
+        <ctl name="RX INT1_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX INT1 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="RX INT2 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="COMP1 Switch" value="0" />
+        <ctl name="COMP2 Switch" value="0" />
+        <ctl name="HPHL Volume" value="20" />
+        <ctl name="HPHR Volume" value="20" />
+        <ctl name="RX1 Digital Volume" value="84" />
+        <ctl name="RX2 Digital Volume" value="84" />
+    </path>
+
+    <!-- ====================================================== -->
+    <!--  common sequence for non call devices for pcm offload  -->
+    <!-- ====================================================== -->
+
+    <path name="anc-off-pcm-offload">
+        <ctl name="ADC MUX10" value="ZERO" />
+        <ctl name="AMIC MUX10" value="ZERO" />
+        <ctl name="ADC MUX12" value="ZERO" />
+        <ctl name="AMIC MUX12" value="ZERO" />
+        <ctl name="ADC3 Volume" value="0" />
+        <ctl name="ADC2 Volume" value="0" />
+        <ctl name="ANC0 FB MUX" value="ZERO" />
+        <ctl name="ANC1 FB MUX" value="ZERO" />
+        <ctl name="ANC Function" value="OFF" />
+    </path>
+
+    <path name="anc-on-pcm-offload">
+        <ctl name="ANC Function" value="ON" />
+        <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM RX1 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM_0_RX Channels" value="Two" />
+        <ctl name="RX INT1_1 MIX1 INP0" value="RX0" />
+        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX INT1 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="RX INT2 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="COMP1 Switch" value="0" />
+        <ctl name="COMP2 Switch" value="0" />
+        <ctl name="HPHL Volume" value="20" />
+        <ctl name="HPHR Volume" value="20" />
+        <ctl name="RX1 Digital Volume" value="84" />
+        <ctl name="RX2 Digital Volume" value="84" />
+        <ctl name="ADC3 Volume" value="10" />
+        <ctl name="ADC2 Volume" value="10" />
+        <ctl name="ANC0 FB MUX" value="ANC_IN_HPHL" />
+        <ctl name="ANC1 FB MUX" value="ANC_IN_HPHR" />
+        <ctl name="ANC HPHL Enable Switch" value="1" />
+        <ctl name="ANC HPHR Enable Switch" value="1" />
+    </path>
+
+    <path name="anc-on-pcm-offload-regulation">
+        <ctl name="ANC Function" value="ON" />
+        <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM RX1 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM_0_RX Channels" value="Two" />
+        <ctl name="RX INT1_1 MIX1 INP0" value="RX0" />
+        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX INT1 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="RX INT2 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="COMP1 Switch" value="0" />
+        <ctl name="COMP2 Switch" value="0" />
+        <ctl name="HPHL Volume" value="20" />
+        <ctl name="HPHR Volume" value="20" />
+        <ctl name="RX1 Digital Volume" value="77" />
+        <ctl name="RX2 Digital Volume" value="77" />
+        <ctl name="ADC3 Volume" value="10" />
+        <ctl name="ADC2 Volume" value="10" />
+        <ctl name="ANC0 FB MUX" value="ANC_IN_HPHL" />
+        <ctl name="ANC1 FB MUX" value="ANC_IN_HPHR" />
+        <ctl name="ANC HPHL Enable Switch" value="1" />
+        <ctl name="ANC HPHR Enable Switch" value="1" />
+    </path>
+
+    <path name="anc2-off-pcm-offload">
+        <path name="anc-off-pcm-offload" />
+    </path>
+
+    <path name="anc2-on-pcm-offload">
+        <ctl name="ANC Function" value="ON" />
+        <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM RX1 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM_0_RX Channels" value="Two" />
+        <ctl name="RX INT1_1 MIX1 INP0" value="RX0" />
+        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX INT1 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="RX INT2 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="COMP1 Switch" value="0" />
+        <ctl name="COMP2 Switch" value="0" />
+        <ctl name="HPHL Volume" value="20" />
+        <ctl name="HPHR Volume" value="20" />
+        <ctl name="RX1 Digital Volume" value="84" />
+        <ctl name="RX2 Digital Volume" value="84" />
+        <ctl name="ADC3 Volume" value="10" />
+        <ctl name="ADC2 Volume" value="10" />
+        <ctl name="ANC0 FB MUX" value="ANC_IN_HPHL" />
+        <ctl name="ANC1 FB MUX" value="ANC_IN_HPHR" />
+        <ctl name="ANC HPHL Enable Switch" value="1" />
+        <ctl name="ANC HPHR Enable Switch" value="1" />
+    </path>
+
+    <path name="anc2-on-pcm-offload-regulation">
+        <ctl name="ANC Function" value="ON" />
+        <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM RX1 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM_0_RX Channels" value="Two" />
+        <ctl name="RX INT1_1 MIX1 INP0" value="RX0" />
+        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX INT1 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="RX INT2 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="COMP1 Switch" value="0" />
+        <ctl name="COMP2 Switch" value="0" />
+        <ctl name="HPHL Volume" value="20" />
+        <ctl name="HPHR Volume" value="20" />
+        <ctl name="RX1 Digital Volume" value="77" />
+        <ctl name="RX2 Digital Volume" value="77" />
+        <ctl name="ADC3 Volume" value="10" />
+        <ctl name="ADC2 Volume" value="10" />
+        <ctl name="ANC0 FB MUX" value="ANC_IN_HPHL" />
+        <ctl name="ANC1 FB MUX" value="ANC_IN_HPHR" />
+        <ctl name="ANC HPHL Enable Switch" value="1" />
+        <ctl name="ANC HPHR Enable Switch" value="1" />
+    </path>
+
+    <!-- ============================================= -->
+    <!--    common sequence for call devices           -->
+    <!-- ============================================= -->
+
+    <path name="voiceanc-headphone">
+        <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM RX1 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM_0_RX Channels" value="Two" />
+        <ctl name="RX INT1_1 MIX1 INP0" value="RX0" />
+        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX INT1 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="RX INT2 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="COMP1 Switch" value="0" />
+        <ctl name="COMP2 Switch" value="0" />
+        <ctl name="HPHL Volume" value="20" />
+        <ctl name="HPHR Volume" value="20" />
+        <ctl name="RX1 Digital Volume" value="83" />
+        <ctl name="RX2 Digital Volume" value="83" />
+    </path>
+
+    <path name="voiceanc-headphone-eq1">
+        <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM RX1 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM_0_RX Channels" value="Two" />
+        <ctl name="RX INT1_1 MIX1 INP0" value="RX0" />
+        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX INT1 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="RX INT2 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="COMP1 Switch" value="0" />
+        <ctl name="COMP2 Switch" value="0" />
+        <ctl name="HPHL Volume" value="20" />
+        <ctl name="HPHR Volume" value="20" />
+        <ctl name="RX1 Digital Volume" value="83" />
+        <ctl name="RX2 Digital Volume" value="83" />
+    </path>
+
+    <path name="voiceanc-headset">
+        <ctl name="AIF1_CAP Mixer SLIM TX7" value="1"/>
+        <ctl name="AIF1_CAP Mixer SLIM TX8" value="1" />
+        <ctl name="SLIM_0_TX Channels" value="Two" />
+        <ctl name="SLIM TX7 MUX" value="DEC7" />
+        <ctl name="SLIM TX8 MUX" value="DEC8" />
+        <ctl name="ADC MUX7" value="AMIC" />
+        <ctl name="AMIC MUX7" value="ADC2" />
+        <ctl name="ADC MUX8" value="AMIC" />
+        <ctl name="AMIC MUX8" value="ADC3" />
+        <ctl name="IIR0 INP0 MUX" value="DEC7" />
+        <ctl name="IIR0 INP1 MUX" value="DEC8" />
+        <ctl name="DEC7 Volume" value="84" />
+        <ctl name="DEC8 Volume" value="84" />
+        <ctl name="ADC2 Volume" value="10" />
+        <ctl name="ADC3 Volume" value="10" />
+    </path>
+
+    <path name="voiceanc2-headset">
+        <ctl name="AIF1_CAP Mixer SLIM TX7" value="1"/>
+        <ctl name="AIF1_CAP Mixer SLIM TX8" value="1" />
+        <ctl name="SLIM_0_TX Channels" value="Two" />
+        <ctl name="SLIM TX7 MUX" value="DEC7" />
+        <ctl name="SLIM TX8 MUX" value="DEC8" />
+        <ctl name="ADC MUX7" value="AMIC" />
+        <ctl name="AMIC MUX7" value="ADC2" />
+        <ctl name="ADC MUX8" value="AMIC" />
+        <ctl name="AMIC MUX8" value="ADC3" />
+        <ctl name="IIR0 INP0 MUX" value="DEC7" />
+        <ctl name="IIR0 INP1 MUX" value="DEC8" />
+        <ctl name="DEC7 Volume" value="84" />
+        <ctl name="DEC8 Volume" value="84" />
+        <ctl name="ADC2 Volume" value="10" />
+        <ctl name="ADC3 Volume" value="10" />
+    </path>
+
+    <path name="voipanc-headset">
+        <ctl name="AIF1_CAP Mixer SLIM TX7" value="1"/>
+        <ctl name="AIF1_CAP Mixer SLIM TX8" value="1" />
+        <ctl name="SLIM_0_TX Channels" value="Two" />
+        <ctl name="SLIM TX7 MUX" value="DEC7" />
+        <ctl name="SLIM TX8 MUX" value="DEC8" />
+        <ctl name="ADC MUX7" value="AMIC" />
+        <ctl name="AMIC MUX7" value="ADC2" />
+        <ctl name="ADC MUX8" value="AMIC" />
+        <ctl name="AMIC MUX8" value="ADC3" />
+        <ctl name="IIR0 INP0 MUX" value="DEC7" />
+        <ctl name="IIR0 INP1 MUX" value="DEC8" />
+        <ctl name="DEC7 Volume" value="84" />
+        <ctl name="DEC8 Volume" value="84" />
+        <ctl name="ADC2 Volume" value="10" />
+        <ctl name="ADC3 Volume" value="10" />
+    </path>
+
+    <path name="voipanc2-headset">
+        <ctl name="AIF1_CAP Mixer SLIM TX7" value="1"/>
+        <ctl name="AIF1_CAP Mixer SLIM TX8" value="1" />
+        <ctl name="SLIM_0_TX Channels" value="Two" />
+        <ctl name="SLIM TX7 MUX" value="DEC7" />
+        <ctl name="SLIM TX8 MUX" value="DEC8" />
+        <ctl name="ADC MUX7" value="AMIC" />
+        <ctl name="AMIC MUX7" value="ADC2" />
+        <ctl name="ADC MUX8" value="AMIC" />
+        <ctl name="AMIC MUX8" value="ADC3" />
+        <ctl name="IIR0 INP0 MUX" value="DEC7" />
+        <ctl name="IIR0 INP1 MUX" value="DEC8" />
+        <ctl name="DEC7 Volume" value="84" />
+        <ctl name="DEC8 Volume" value="84" />
+        <ctl name="ADC2 Volume" value="10" />
+        <ctl name="ADC3 Volume" value="10" />
+    </path>
+
+    <!-- ========  NC  ======== -->
+
+    <path name="anc-nc-headphone">
+    </path>
+
+    <path name="anc-nc-headphone-regulation">
+    </path>
+
+    <path name="anc-nc-off-headphone">
+        <path name="anc-off-headphone" />
+    </path>
+
+    <path name="anc-nc-off-headphone-regulation">
+        <path name="anc-off-headphone-regulation" />
+    </path>
+
+    <path name="speaker-anc-nc-headphone">
+        <path name="speaker" />
+        <path name="anc-nc-headphone" />
+        <ctl name="RX INT1_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX1 Digital Volume" value="50" />
+        <ctl name="RX2 Digital Volume" value="50" />
+        <path name="headphones-hpf" />
+        <ctl name="Set Custom Stereo" value="Mix" />
+    </path>
+
+    <path name="speaker-anc-nc-off-headphone">
+        <path name="speaker" />
+        <path name="anc-off-headphone-combo" />
+        <ctl name="RX1 Digital Volume" value="50" />
+        <ctl name="RX2 Digital Volume" value="50" />
+        <path name="headphones-hpf" />
+        <ctl name="Set Custom Stereo" value="Mix" />
+    </path>
+
+    <path name="speaker-mono-ring-anc-nc-headphone">
+        <path name="ringtone-speaker-mono" />
+        <path name="anc-nc-headphone" />
+        <ctl name="RX INT1_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX1 Digital Volume" value="50" />
+        <ctl name="RX2 Digital Volume" value="50" />
+        <path name="headphones-hpf" />
+    </path>
+
+    <path name="speaker-mono-ring-anc-nc-off-headphone">
+        <path name="ringtone-speaker-mono" />
+        <path name="anc-off-headphone-combo" />
+        <ctl name="RX1 Digital Volume" value="50" />
+        <ctl name="RX2 Digital Volume" value="50" />
+        <path name="headphones-hpf" />
+    </path>
+
+    <path name="speaker-ring-anc-nc-headphone">
+        <path name="ringtone-speaker" />
+        <path name="anc-nc-headphone" />
+        <ctl name="RX INT1_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX1 Digital Volume" value="50" />
+        <ctl name="RX2 Digital Volume" value="50" />
+        <path name="headphones-hpf" />
+    </path>
+
+    <path name="speaker-ring-anc-nc-off-headphone">
+        <path name="ringtone-speaker" />
+        <path name="anc-off-headphone-combo" />
+        <ctl name="RX1 Digital Volume" value="50" />
+        <ctl name="RX2 Digital Volume" value="50" />
+        <path name="headphones-hpf" />
+    </path>
+
+    <path name="voiceanc-nc-headphone">
+        <path name="voiceanc-headphone" />
+        <ctl name="RX1 Digital Volume" value="78" />
+        <ctl name="RX2 Digital Volume" value="78" />
+    </path>
+
+    <path name="voiceanc-nc-headphone-eq1">
+        <path name="voiceanc-headphone-eq1" />
+        <ctl name="RX1 Digital Volume" value="78" />
+        <ctl name="RX2 Digital Volume" value="78" />
+    </path>
+
+    <!-- ========  NCE  ======== -->
+
+    <path name="anc-nce-headphone">
+    </path>
+
+    <path name="anc-nce-headphone-regulation">
+    </path>
+
+    <path name="anc-nce-off-headphone">
+        <path name="anc-off-headphone" />
+    </path>
+
+    <path name="anc-nce-off-headphone-regulation">
+        <path name="anc-off-headphone-regulation" />
+    </path>
+
+    <path name="speaker-anc-nce-headphone">
+        <path name="speaker" />
+        <path name="anc-nce-headphone" />
+        <ctl name="RX INT1_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX1 Digital Volume" value="56" />
+        <ctl name="RX2 Digital Volume" value="56" />
+        <path name="headphones-hpf" />
+        <ctl name="Set Custom Stereo" value="Mix" />
+    </path>
+
+    <path name="speaker-anc-nce-off-headphone">
+        <path name="speaker" />
+        <path name="anc-off-headphone-combo" />
+        <ctl name="RX1 Digital Volume" value="56" />
+        <ctl name="RX2 Digital Volume" value="56" />
+        <path name="headphones-hpf" />
+        <ctl name="Set Custom Stereo" value="Mix" />
+    </path>
+
+    <path name="speaker-mono-ring-anc-nce-headphone">
+        <path name="ringtone-speaker-mono" />
+        <path name="anc-nce-headphone" />
+        <ctl name="RX INT1_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX1 Digital Volume" value="56" />
+        <ctl name="RX2 Digital Volume" value="56" />
+        <path name="headphones-hpf" />
+    </path>
+
+    <path name="speaker-mono-ring-anc-nce-off-headphone">
+        <path name="ringtone-speaker-mono" />
+        <path name="anc-off-headphone-combo" />
+        <ctl name="RX1 Digital Volume" value="56" />
+        <ctl name="RX2 Digital Volume" value="56" />
+        <path name="headphones-hpf" />
+    </path>
+
+    <path name="speaker-ring-anc-nce-headphone">
+        <path name="ringtone-speaker" />
+        <path name="anc-nce-headphone" />
+        <ctl name="RX INT1_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX1 Digital Volume" value="56" />
+        <ctl name="RX2 Digital Volume" value="56" />
+        <path name="headphones-hpf" />
+    </path>
+
+    <path name="speaker-ring-anc-nce-off-headphone">
+        <path name="ringtone-speaker" />
+        <path name="anc-off-headphone-combo" />
+        <ctl name="RX1 Digital Volume" value="56" />
+        <ctl name="RX2 Digital Volume" value="56" />
+        <path name="headphones-hpf" />
+    </path>
+
+    <path name="voiceanc-nce-headphone">
+        <path name="voiceanc-headphone" />
+    </path>
+
+    <path name="voiceanc-nce-headphone-eq1">
+        <path name="voiceanc-headphone-eq1" />
+    </path>
+
+    <!-- ========  ANC2 NC  ======== -->
+
+    <path name="anc2-nc-headphone">
+    </path>
+
+    <path name="anc2-nc-headphone-regulation">
+    </path>
+
+    <path name="anc2-nc-off-headphone">
+        <path name="anc-off-headphone" />
+    </path>
+
+    <path name="anc2-nc-off-headphone-regulation">
+        <path name="anc-off-headphone-regulation" />
+    </path>
+
+    <path name="speaker-anc2-nc-headphone">
+        <path name="speaker" />
+        <path name="anc2-nc-headphone" />
+        <ctl name="RX INT1_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX1 Digital Volume" value="50" />
+        <ctl name="RX2 Digital Volume" value="50" />
+        <path name="headphones-hpf" />
+        <ctl name="Set Custom Stereo" value="Mix" />
+    </path>
+
+    <path name="speaker-anc2-nc-off-headphone">
+        <path name="speaker" />
+        <path name="anc-off-headphone-combo" />
+        <ctl name="RX1 Digital Volume" value="50" />
+        <ctl name="RX2 Digital Volume" value="50" />
+        <path name="headphones-hpf" />
+        <ctl name="Set Custom Stereo" value="Mix" />
+    </path>
+
+    <path name="speaker-mono-ring-anc2-nc-headphone">
+        <path name="ringtone-speaker-mono" />
+        <path name="anc2-nc-headphone" />
+        <ctl name="RX INT1_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX1 Digital Volume" value="50" />
+        <ctl name="RX2 Digital Volume" value="50" />
+        <path name="headphones-hpf" />
+    </path>
+
+    <path name="speaker-mono-ring-anc2-nc-off-headphone">
+        <path name="ringtone-speaker-mono" />
+        <path name="anc-off-headphone-combo" />
+        <ctl name="RX1 Digital Volume" value="50" />
+        <ctl name="RX2 Digital Volume" value="50" />
+        <path name="headphones-hpf" />
+    </path>
+
+    <path name="speaker-ring-anc2-nc-headphone">
+        <path name="ringtone-speaker" />
+        <path name="anc2-nc-headphone" />
+        <ctl name="RX INT1_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX1 Digital Volume" value="50" />
+        <ctl name="RX2 Digital Volume" value="50" />
+        <path name="headphones-hpf" />
+    </path>
+
+    <path name="speaker-ring-anc2-nc-off-headphone">
+        <path name="ringtone-speaker" />
+        <path name="anc-off-headphone-combo" />
+        <ctl name="RX1 Digital Volume" value="50" />
+        <ctl name="RX2 Digital Volume" value="50" />
+        <path name="headphones-hpf" />
+    </path>
+
+    <path name="voiceanc2-nc-headphone">
+        <path name="voiceanc-headphone" />
+        <ctl name="RX1 Digital Volume" value="78" />
+        <ctl name="RX2 Digital Volume" value="78" />
+    </path>
+
+    <path name="voiceanc2-nc-headphone-eq1">
+        <path name="voiceanc-headphone-eq1" />
+        <ctl name="RX1 Digital Volume" value="78" />
+        <ctl name="RX2 Digital Volume" value="78" />
+    </path>
+
+    <!-- ========  ANC2 NCE  ======== -->
+
+    <path name="anc2-nce-headphone">
+    </path>
+
+    <path name="anc2-nce-headphone-regulation">
+    </path>
+
+    <path name="anc2-nce-off-headphone">
+        <path name="anc-off-headphone" />
+    </path>
+
+    <path name="anc2-nce-off-headphone-regulation">
+        <path name="anc-off-headphone-regulation" />
+    </path>
+
+    <path name="speaker-anc2-nce-headphone">
+        <path name="speaker" />
+        <path name="anc2-nce-headphone" />
+        <ctl name="RX INT1_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX1 Digital Volume" value="56" />
+        <ctl name="RX2 Digital Volume" value="56" />
+        <path name="headphones-hpf" />
+        <ctl name="Set Custom Stereo" value="Mix" />
+    </path>
+
+    <path name="speaker-anc2-nce-off-headphone">
+        <path name="speaker" />
+        <path name="anc-off-headphone-combo" />
+        <ctl name="RX1 Digital Volume" value="56" />
+        <ctl name="RX2 Digital Volume" value="56" />
+        <path name="headphones-hpf" />
+        <ctl name="Set Custom Stereo" value="Mix" />
+    </path>
+
+    <path name="speaker-mono-ring-anc2-nce-headphone">
+        <path name="ringtone-speaker-mono" />
+        <path name="anc2-nce-headphone" />
+        <ctl name="RX INT1_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX1 Digital Volume" value="56" />
+        <ctl name="RX2 Digital Volume" value="56" />
+        <path name="headphones-hpf" />
+    </path>
+
+    <path name="speaker-mono-ring-anc2-nce-off-headphone">
+        <path name="ringtone-speaker-mono" />
+        <path name="anc-off-headphone-combo" />
+        <ctl name="RX1 Digital Volume" value="56" />
+        <ctl name="RX2 Digital Volume" value="56" />
+        <path name="headphones-hpf" />
+    </path>
+
+    <path name="speaker-ring-anc2-nce-headphone">
+        <path name="ringtone-speaker" />
+        <path name="anc2-nce-headphone" />
+        <ctl name="RX INT1_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX1 Digital Volume" value="56" />
+        <ctl name="RX2 Digital Volume" value="56" />
+        <path name="headphones-hpf" />
+    </path>
+
+    <path name="speaker-ring-anc2-nce-off-headphone">
+        <path name="ringtone-speaker" />
+        <path name="anc-off-headphone-combo" />
+        <ctl name="RX1 Digital Volume" value="56" />
+        <ctl name="RX2 Digital Volume" value="56" />
+        <path name="headphones-hpf" />
+    </path>
+
+    <path name="voiceanc2-nce-headphone">
+        <path name="voiceanc-headphone" />
+    </path>
+
+    <path name="voiceanc2-nce-headphone-eq1">
+        <path name="voiceanc-headphone-eq1" />
+    </path>
+
+    <!-- ============================================= -->
+    <!--            env type devices                   -->
+    <!-- ============================================= -->
+
+    <path name="anc-mux-on">
+        <ctl name="ADC MUX10" value="AMIC" />
+        <ctl name="AMIC MUX10" value="ADC3" />
+        <ctl name="ADC MUX12" value="AMIC" />
+        <ctl name="AMIC MUX12" value="ADC2" />
+    </path>
+
+    <path name="anc-mux-off">
+        <ctl name="ADC MUX10" value="ZERO" />
+        <ctl name="AMIC MUX10" value="ZERO" />
+        <ctl name="ADC MUX12" value="ZERO" />
+        <ctl name="AMIC MUX12" value="ZERO" />
+    </path>
+
+    <!-- ========  NC  ======== -->
+
+    <path name="anc-type-0-bus-train-mode">
+        <ctl name="ANC Slot" value="3" />
+        <path name="anc-mux-on" />
+    </path>
+
+    <path name="anc-type-0-airplane-mode">
+        <ctl name="ANC Slot" value="4" />
+        <path name="anc-mux-on" />
+    </path>
+
+    <path name="anc-type-0-office-mode">
+        <ctl name="ANC Slot" value="5" />
+        <path name="anc-mux-on" />
+    </path>
+
+    <!-- ========  NCE  ======== -->
+
+    <path name="anc-type-1-bus-train-mode">
+        <ctl name="ANC Slot" value="0" />
+        <path name="anc-mux-on" />
+    </path>
+
+    <path name="anc-type-1-airplane-mode">
+        <ctl name="ANC Slot" value="1" />
+        <path name="anc-mux-on" />
+    </path>
+
+    <path name="anc-type-1-office-mode">
+        <ctl name="ANC Slot" value="2" />
+        <path name="anc-mux-on" />
+    </path>
+
+    <!-- ========  ANC2 NC  ======== -->
+
+    <path name="anc2-type-2-bus-train-mode">
+        <ctl name="ANC Slot" value="17" />
+        <path name="anc-mux-on" />
+    </path>
+
+    <path name="anc2-type-2-airplane-mode">
+        <ctl name="ANC Slot" value="18" />
+        <path name="anc-mux-on" />
+    </path>
+
+    <path name="anc2-type-2-office-mode">
+        <ctl name="ANC Slot" value="19" />
+        <path name="anc-mux-on" />
+    </path>
+
+    <!-- ========  ANC2 NCE  ======== -->
+
+    <path name="anc2-type-3-bus-train-mode">
+        <ctl name="ANC Slot" value="14" />
+        <path name="anc-mux-on" />
+    </path>
+
+    <path name="anc2-type-3-airplane-mode">
+        <ctl name="ANC Slot" value="15" />
+        <path name="anc-mux-on" />
+    </path>
+
+    <path name="anc2-type-3-office-mode">
+        <ctl name="ANC Slot" value="16" />
+        <path name="anc-mux-on" />
+    </path>
+
+    <!-- ========  no use  ======== -->
+
+    <path name="anc-type-voice-anc-headphone-mode">
+        <ctl name="ANC Slot" value="6" />
+        <path name="anc-mux-on" />
+    </path>
+
+    <path name="anc-type-voice-anc-headphone-eq1-mode">
+        <ctl name="ANC Slot" value="7" />
+        <path name="anc-mux-on" />
+    </path>
+
+    <path name="anc-rx-inp-mix1-off">
+        <ctl name="RX INT1_1 MIX1 INP0" value="ZERO" />
+        <ctl name="RX INT2_1 MIX1 INP0" value="ZERO" />
+    </path>
+
+    <path name="anc-rx-inp-mix2-iir">
+        <ctl name="RX INT1 MIX2 INP" value="SRC0" />
+        <ctl name="RX INT2 MIX2 INP" value="SRC1" />
+    </path>
+
+    <path name="anc-slim-rx-mux-off">
+        <ctl name="SLIM RX0 MUX" value="ZERO" />
+        <ctl name="SLIM RX1 MUX" value="ZERO" />
+    </path>
+
+    <path name="anc-slim-rx1-mux-aif">
+        <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
+    </path>
+
+    <path name="anc-slim-rx2-mux-aif">
+        <ctl name="SLIM RX1 MUX" value="AIF_MIX1_PB" />
+    </path>
+
+    <path name="anc-dec-vol-zero">
+        <ctl name="DEC7 Volume" value="0" />
+        <ctl name="DEC8 Volume" value="0" />
+    </path>
+
+    <path name="anc-preparation-rx">
+        <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM RX1 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM_0_RX Channels" value="Two" />
+        <ctl name="RX INT1_1 MIX1 INP0" value="RX0" />
+        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
+    </path>
+
+    <path name="anc-preparation-combo-rx">
+        <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM RX1 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM_0_RX Channels" value="Two" />
+        <ctl name="RX INT1_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
+    </path>
+
+</mixer>


### PR DESCRIPTION
Note: diff between Suzu and Kugo mixer_paths:
**Kugo:** https://hastebin.com/zeceroyave.xml
**Suzu:** https://hastebin.com/jorocedoha.xml
Was taken variant with the volumes from Suzu,
so it must be carefully tested on Kugo device