### PR TITLE
[LOIRE] Add properties to avoid UBWC buffers on VENC

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -140,6 +140,14 @@ PRODUCT_PROPERTY_OVERRIDES += \
     vidc.enc.disable_bframes=1 \
     vidc.enc.disable_pframes=1 \
     vidc.disable.split.mode=1
+    
+## Avoid unsupported UBWC buffers on VENC
+PRODUCT_PROPERTY_OVERRIDES += \
+    debug.gralloc.gfx_ubwc_disable=1 \
+    debug.gralloc.gfx_ubwc_disable_=1 \
+    debug.gralloc.enable_fb_ubwc=0 \
+    video.disable.ubwc=1
+    
 
 # USB controller setup
 PRODUCT_PROPERTY_OVERRIDES += \


### PR DESCRIPTION
MSM8956 Venus does not support UBWC. Make sure it never gets
enabled.

----------------------
Tested on Suzu. Fixes the weird Instagram issue.