### PR TITLE
[LOIRE] ueventd: Fix for FPC IOCTL implementation

### DIFF
--- a/rootdir/ueventd.loire.rc
+++ b/rootdir/ueventd.loire.rc
@@ -113,6 +113,9 @@
 /dev/ttyHS0                                         0660 bluetooth bluetooth
 /dev/ttyMSM0                                        0660 bluetooth bluetooth
 
+# Fingerprint sensor  device
+/dev/fingerprint         0664 system input
+
 # NFC
 /dev/pn54x                                               0660 nfc nfc
 /sys/devices/soc/7af6000.i2c/i2c-6/6-0028  init_deinit   0200 nfc nfc


### PR DESCRIPTION
Add /dev/fingerprint perms for the new IOCTL implementation.