### PR TITLE
[master] init.loire.rc: Do not reserve CPU 3 for the camera daemon

### DIFF
--- a/rootdir/init.loire.rc
+++ b/rootdir/init.loire.rc
@@ -23,13 +23,11 @@ on boot
     chown wifi wifi /sys/module/bcmdhd/parameters/firmware_path
 
     # Update foreground cpuset now that processors are up
-    # reserve CPU 3 for the top app and camera daemon
-    write /dev/cpuset/foreground/cpus 0-2,4-5
+    write /dev/cpuset/foreground/cpus 0-5
     write /dev/cpuset/foreground/boost/cpus 4-5
     write /dev/cpuset/background/cpus 0
     write /dev/cpuset/system-background/cpus 0-2
     write /dev/cpuset/top-app/cpus 0-5
-    write /dev/cpuset/camera-daemon/cpus 0-3
 
 # OSS WLAN and BT MAC setup
 service macaddrsetup /vendor/bin/macaddrsetup /sys/devices/soc/soc:bcmdhd_wlan/macaddr


### PR DESCRIPTION
Camera daemon is no longer used so it makes no sense to reserve
CPU 3 for the camera daemon.

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>