### PR TITLE
loire: define macaddr sys path for bcm

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -149,3 +149,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     sys.usb.controller=msm_hsusb \
     sys.usb.rndis.func.name=rndis_bam
+
+# MAC
+PRODUCT_PROPERTY_OVERRIDES += \
+    ro.wifi.addr_path=sys/devices/soc/soc:bcmdhd_wlan/macaddr


### PR DESCRIPTION
Signed-off-by: David Viteri <davidteri91@gmail.com>