### PR TITLE
[master] sony: loire: graphics: Disable Vulkan for 8952

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -138,6 +138,10 @@ PRODUCT_PROPERTY_OVERRIDES += \
     vidc.enc.disable_pframes=1 \
     vidc.disable.split.mode=1
 
+# Disable Vulkan
+PRODUCT_PROPERTY_OVERRIDES += \
+    persist.graphics.vulkan.disable=true
+
 ## Avoid unsupported UBWC buffers on VENC
 PRODUCT_PROPERTY_OVERRIDES += \
     debug.gralloc.gfx_ubwc_disable=1 \


### PR DESCRIPTION
Vulkan is not supported on 8952
Set "persist.graphics.vulkan.disable" for Soc_id 264 to true.
Framework checks for this flag and disables
Vulkan features for 8952.

Signed-off-by: Humberto Borba <humberos@omnirom.org>
Change-Id: I32c42d0ca488b22c3a3cac96044bdf6356535c11