### PR TITLE
[LOIRE] platform: Use MSM8956 featureset for vidc encoders

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -149,6 +149,10 @@ PRODUCT_PROPERTY_OVERRIDES += \
     debug.gralloc.enable_fb_ubwc=0 \
     video.disable.ubwc=1
 
+# Use MSM8956 feature set for vidc encoders
+PRODUCT_PROPERTY_OVERRIDES += \
+    media.msm8956hw=1
+
 # USB controller setup
 PRODUCT_PROPERTY_OVERRIDES += \
     sys.usb.controller=msm_hsusb \


### PR DESCRIPTION
This is required for the media HAL to respect MSM8956
features, such as declaring the correct AVC Level 5.1 and
disabling the unsupported intra-refresh mode for MPEG4.