### PR TITLE
[master] Revert "sony: loire: graphics: Disable Vulkan for 8952"

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -138,10 +138,6 @@ PRODUCT_PROPERTY_OVERRIDES += \
     vidc.enc.disable_pframes=1 \
     vidc.disable.split.mode=1
 
-# Disable Vulkan
-PRODUCT_PROPERTY_OVERRIDES += \
-    persist.graphics.vulkan.disable=true
-
 ## Avoid unsupported UBWC buffers on VENC
 PRODUCT_PROPERTY_OVERRIDES += \
     debug.gralloc.gfx_ubwc_disable=1 \


### PR DESCRIPTION
This patch was for MSM8952 and loire is MSM8956
So it is a mistake.

Thanks to @oshmoun for reviewing this.

This reverts commit 5d6c6cf36300b5f3e201dd2bc9dcc213ad92cbff.

Change-Id: I772545d0e2269e28719ef3f60b81319c29057f46