### PR TITLE
[master] fstab: Fix USB-OTG

### DIFF
--- a/rootdir/fstab.loire
+++ b/rootdir/fstab.loire
@@ -14,6 +14,6 @@
 /dev/block/bootdevice/by-name/modem        /firmware    vfat    ro,shortname=lower,uid=1000,gid=1000,dmask=227,fmask=337,context=u:object_r:firmware_file:s0 wait
 /dev/block/bootdevice/by-name/persist      /persist     ext4    nosuid,nodev,barrier=1,data=ordered,nodelalloc,errors=panic   wait,notrim
 
-/devices/soc/7864900.sdhci/mmc_host/mmc*  auto         auto    nosuid,nodev                                      voldmanaged=sdcard1:auto,encryptable=userdata
-/devices/platform/msm_hsusb_host/usb*       auto         auto    nosuid,nodev                                      voldmanaged=usb:auto
-/dev/block/zram0                            none         swap    defaults                                          zramsize=536870912,notrim
+/devices/soc/7864900.sdhci/mmc_host/mmc*   auto         auto    nosuid,nodev                                                  voldmanaged=sdcard1:auto,encryptable=userdata
+/devices/platform/msm_hsusb*               auto         auto    nosuid,nodev                                                  voldmanaged=usb:auto
+/dev/block/zram0                           none         swap    defaults                                                      zramsize=536870912,notrim


### PR DESCRIPTION
Fix the wrong USB-OTG path to be able to mount
the external storage.

Also align whitespaces.

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>