### PR TITLE
[DONOTMERGE] rootdir: vendor: update voip acdb ids

### DIFF
--- a/rootdir/vendor/etc/audio_platform_info.xml
+++ b/rootdir/vendor/etc/audio_platform_info.xml
@@ -36,9 +36,9 @@
         <device name="SND_DEVICE_IN_CAMCORDER_MIC" acdb_id="801"/>
         <device name="SND_DEVICE_IN_VOICE_SPEAKER_DMIC" acdb_id="11"/>
         <device name="SND_DEVICE_IN_VOICE_DMIC" acdb_id="6"/>
-        <device name="SND_DEVICE_IN_SPEAKER_DMIC_AEC_NS" acdb_id="578"/>
-        <device name="SND_DEVICE_IN_HANDSET_DMIC_AEC_NS" acdb_id="577"/>
-        <device name="SND_DEVICE_IN_HEADSET_MIC_FLUENCE" acdb_id="579"/>
+        <device name="SND_DEVICE_IN_SPEAKER_DMIC_AEC_NS" acdb_id="117"/>
+        <device name="SND_DEVICE_IN_HANDSET_DMIC_AEC_NS" acdb_id="111"/>
+        <device name="SND_DEVICE_IN_HEADSET_MIC_FLUENCE" acdb_id="47"/>
         <device name="SND_DEVICE_IN_HANDSET_STEREO_DMIC" acdb_id="544"/>
         <!-- Custom mapping ends here -->
     </acdb_ids>


### PR DESCRIPTION
The previous values were causing ADSP errors:
03-21 09:44:33.142 0 0 E send_adm_cal_block: DSP returned error[ADSP_EBADPARAM]

The default HAL values seem to be working fine, so switch to those.

Change-Id: I8d1085f4223ef9beaa9c3d6757a862adb79efb4d