### PR TITLE
ueventd: add mdss_rotator perms

### DIFF
--- a/rootdir/vendor/ueventd.rc
+++ b/rootdir/vendor/ueventd.rc
@@ -51,6 +51,7 @@
 /dev/jpeg2                0660   system     camera
 /dev/adsprpc-smd          0664   system     system
 /dev/system_health_monitor 0640  radio      system
+/dev/mdss_rotator         0664   system     system
 /dev/msm_rotator          0660   system     system
 /dev/hw_random            0660   system     system
 /dev/adsprpc-smd          0664   system     system


### PR DESCRIPTION
07-13 13:35:50.846  2502  2502 W SDM     : HWRotator::Open: open /dev/mdss_rotator failed err = 13 errstr = Permission denied
07-13 13:35:50.846  2502  2502 W SDM     : Rotator::Init: Failed to open rotator device

Signed-off-by: David Viteri <davidteri91@gmail.com>