### PR TITLE
loire: add guard to serial console

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -44,7 +44,9 @@ BOARD_RAMDISK_OFFSET     := 0x02000000
 BOARD_KERNEL_CMDLINE += androidboot.bootdevice=7824900.sdhci
 
 # Serial console
-#BOARD_KERNEL_CMDLINE += earlycon=msm_serial_dm,0x7af0000 androidboot.console=msm_serial_dm,0x7af0000
+ifeq ($(BOARD_ENABLE_SERIAL_CONSOLE),true)
+BOARD_KERNEL_CMDLINE += earlycon=msm_serial_dm,0x7af0000 androidboot.console=msm_serial_dm,0x7af0000
+endif
 
 TARGET_RECOVERY_FSTAB = $(PLATFORM_COMMON_PATH)/rootdir/vendor/etc/fstab.loire
 


### PR DESCRIPTION
enable it by a flag when is needed

Signed-off-by: David Viteri <davidteri91@gmail.com>