### PR TITLE
rootdir: vendor: Adjust minimum frequencies and touch boost

### DIFF
--- a/rootdir/vendor/etc/init/init.loire.pwr.rc
+++ b/rootdir/vendor/etc/init/init.loire.pwr.rc
@@ -58,7 +58,7 @@ on property:sys.boot_completed=1
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/timer_rate 20000
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/io_is_busy 0
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/min_sample_time 40000
-    write /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq 691200
+    write /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq 600000
 
     # enable governor for perf cluster
     write /sys/devices/system/cpu/cpu4/online 1
@@ -68,7 +68,7 @@ on property:sys.boot_completed=1
     write /sys/devices/system/cpu/cpu4/cpufreq/interactive/io_is_busy 0
     write /sys/devices/system/cpu/cpu4/cpufreq/interactive/min_sample_time 40000
     write /sys/devices/system/cpu/cpu4/cpufreq/interactive/sampling_down_factor 40000
-    write /sys/devices/system/cpu/cpu4/cpufreq/scaling_min_freq 883200
+    write /sys/devices/system/cpu/cpu4/cpufreq/scaling_min_freq 800000
     write /sys/devices/system/cpu/cpu4/cpufreq/interactive/max_freq_hysteresis 60000
 
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/above_hispeed_delay 59000
@@ -101,7 +101,7 @@ on property:sys.boot_completed=1
     write /sys/devices/soc/soc:qcom,bcl/mode "enable"
 
     # set cpu_boost parameters
-    write /sys/module/cpu_boost/parameters/input_boost_freq "0:1305600"
+    write /sys/module/cpu_boost/parameters/input_boost_freq "0:1200000"
     write /sys/module/cpu_boost/parameters/input_boost_ms "40"
 
     # HMP scheduler (big.Little cluster related) settings


### PR DESCRIPTION
The frequencies supported by cpufreq have changed in kernel, so reflect the changes here.