### PR TITLE
Allow overriding TARGET_RECOVERY_FSTAB

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -46,7 +46,7 @@ BOARD_KERNEL_CMDLINE += androidboot.bootdevice=7824900.sdhci
 # Serial console
 #BOARD_KERNEL_CMDLINE += earlycon=msm_serial_dm,0x7af0000 androidboot.console=msm_serial_dm,0x7af0000
 
-TARGET_RECOVERY_FSTAB = $(PLATFORM_COMMON_PATH)/rootdir/vendor/etc/fstab.loire
+TARGET_RECOVERY_FSTAB ?= $(PLATFORM_COMMON_PATH)/rootdir/vendor/etc/fstab.loire
 
 # Wi-Fi definitions for Broadcom solution
 BOARD_WLAN_DEVICE           := bcmdhd


### PR DESCRIPTION
needed to projects like TWRP

Signed-off-by: David Viteri <davidteri91@gmail.com>