### PR TITLE
[master] Remove deprecated paths

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -163,13 +163,8 @@ PRODUCT_PROPERTY_OVERRIDES += \
     sys.usb.rndis.func.name=rndis_bam
 
 # WiFi MAC address path
-ifneq ($(SOMC_KERNEL_VERSION),4.9)
-PRODUCT_PROPERTY_OVERRIDES += \
-    ro.wifi.addr_path=/sys/devices/soc/soc:bcmdhd_wlan/macaddr
-else
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.wifi.addr_path=/sys/devices/platform/soc/soc:bcmdhd_wlan/macaddr
-endif
 
 # setup dm-verity configs.
 PRODUCT_SYSTEM_VERITY_PARTITION := /dev/block/platform/soc/7824900.sdhci/by-name/system

--- a/rootdir/vendor/etc/init/init.loire.rc
+++ b/rootdir/vendor/etc/init/init.loire.rc
@@ -14,7 +14,6 @@
 
 on boot
     # WLAN and BT MAC
-    chown system system /sys/devices/soc/soc:bcmdhd_wlan/macaddr
     chown system system /sys/devices/platform/soc/soc:bcmdhd_wlan/macaddr
     chown wifi wifi /sys/module/bcmdhd/parameters/firmware_path
 

--- a/rootdir/vendor/ueventd.rc
+++ b/rootdir/vendor/ueventd.rc
@@ -118,13 +118,6 @@
 
 # NFC
 /dev/pn54x                                               0660 nfc nfc
-/sys/devices/soc/7af6000.i2c/i2c-6/6-0028  init_deinit   0200 nfc nfc
-/sys/devices/soc/7af6000.i2c/i2c-6/6-0028  set_pwr       0200 nfc nfc
-/sys/devices/soc/7af6000.i2c/i2c-6/6-0028  res_ready     0400 nfc nfc
-/sys/devices/soc/7af6000.i2c/i2c-6/6-0028  recv_rsp      0600 nfc nfc
-/sys/devices/soc/7af6000.i2c/i2c-6/6-0028  send_cmd      0200 nfc nfc
-
-# NFC - k4.9
 /sys/devices/platform/soc/7af6000.i2c/i2c-6/6-0028  init_deinit   0200 nfc nfc
 /sys/devices/platform/soc/7af6000.i2c/i2c-6/6-0028  set_pwr       0200 nfc nfc
 /sys/devices/platform/soc/7af6000.i2c/i2c-6/6-0028  res_ready     0400 nfc nfc
@@ -132,16 +125,6 @@
 /sys/devices/platform/soc/7af6000.i2c/i2c-6/6-0028  send_cmd      0200 nfc nfc
 
 # LED
-/sys/devices/soc/200f000.qcom,spmi/spmi-0/spmi0-03/200f000.qcom,spmi:qcom,pmi8950@3:qcom,leds@d800/leds/wled:backlight max_brightness 0664 system system
-/sys/devices/soc/200f000.qcom,spmi/spmi-0/spmi0-03/200f000.qcom,spmi:qcom,pmi8950@3:qcom,leds@d800/leds/wled:backlight brightness     0664 system system
-/sys/devices/soc/7af6000.i2c/i2c-6/6-0042/leds/led:* max_brightness   0664 system system
-/sys/devices/soc/7af6000.i2c/i2c-6/6-0042/leds/led:* brightness       0664 system system
-/sys/devices/soc/7af6000.i2c/i2c-6/6-0042/leds/led:* blink            0664 system system
-/sys/devices/soc/7af6000.i2c/i2c-6/6-0042  pattern_run                0664 system system
-/sys/class/leds/lcd-backlight max_brightness                          0644 root system
-/sys/class/leds/lcd-backlight brightness                              0664 system system
-
-# LED - k4.9
 /sys/devices/platform/soc/200f000.qcom,spmi/spmi-0/spmi0-03/200f000.qcom,spmi:qcom,pmi8950@3:qcom,leds@d800/leds/wled:backlight max_brightness 0664 system system
 /sys/devices/platform/soc/200f000.qcom,spmi/spmi-0/spmi0-03/200f000.qcom,spmi:qcom,pmi8950@3:qcom,leds@d800/leds/wled:backlight brightness     0664 system system
 /sys/devices/platform/soc/7af6000.i2c/i2c-6/6-0042/leds/led:* max_brightness   0664 system system

--- a/sepolicy_platform/genfs_contexts
+++ b/sepolicy_platform/genfs_contexts
@@ -1,32 +1,6 @@
-genfscon sysfs /bus/esoc/devices                                        u:object_r:sysfs_msm_subsys:s0
+genfscon sysfs /bus/esoc/devices                                                 u:object_r:sysfs_msm_subsys:s0
 
-genfscon sysfs /devices/soc/soc:qcom,mdss_rotator                       u:object_r:sysfs_msm_subsys:s0
-genfscon sysfs /devices/soc/7af6000.i2c                                 u:object_r:sysfs_msm_subsys:s0
-genfscon sysfs /devices/soc/1c00000.qcom,kgsl-3d0                       u:object_r:sysfs_msm_subsys:s0
-genfscon sysfs /devices/soc/c200000.qcom,lpass                          u:object_r:sysfs_msm_subsys:s0
-genfscon sysfs /devices/soc/1a00000.qcom,mdss_mdp                       u:object_r:sysfs_msm_subsys:s0
-genfscon sysfs /devices/soc/4080000.qcom,mss                            u:object_r:sysfs_msm_subsys:s0
-genfscon sysfs /devices/soc/200f000.qcom,spmi                           u:object_r:sysfs_msm_subsys:s0
-genfscon sysfs /devices/soc/1de0000.qcom,venus                          u:object_r:sysfs_msm_subsys:s0
-
-genfscon sysfs /devices/soc/1b0c000.qcom,cci                            u:object_r:sysfs_camera:s0
-genfscon sysfs /devices/soc/1b1c000.qcom,jpeg                           u:object_r:sysfs_camera:s0
-genfscon sysfs /devices/soc/1b00000.qcom,msm-cam                        u:object_r:sysfs_camera:s0
-
-genfscon sysfs /devices/soc/soc:bcm43xx/rfkill/rfkill0/state            u:object_r:sysfs_bluetooth:s0
-genfscon sysfs /devices/soc/soc:bcmdhd_wlan/macaddr                     u:object_r:sysfs_addrsetup:s0
-genfscon sysfs /devices/soc/soc:fpc1145                                 u:object_r:sysfs_fingerprint:s0
-
-genfscon sysfs /devices/soc/7af6000.i2c/i2c-6/6-0042/leds                                                             u:object_r:sysfs_leds:s0
-genfscon sysfs /devices/soc/200f000.qcom,spmi/spmi-0/spmi0-03/200f000.qcom,spmi:qcom,pmi8950@3:qcom,leds@d300/leds    u:object_r:sysfs_leds:s0
-genfscon sysfs /devices/soc/200f000.qcom,spmi/spmi-0/spmi0-03/200f000.qcom,spmi:qcom,pmi8950@3:qcom,leds@d800/leds    u:object_r:sysfs_leds:s0
-
-genfscon sysfs /devices/soc/200f000.qcom,spmi/spmi-0/spmi0-02/200f000.qcom,spmi:qcom,pmi8950@2:qcom,fg/power_supply/bms                              u:object_r:sysfs_batteryinfo:s0
-genfscon sysfs /devices/soc/200f000.qcom,spmi/spmi-0/spmi0-02/200f000.qcom,spmi:qcom,pmi8950@2:qcom,fg/power_supply/bms/capacity                     u:object_r:sysfs_batteryinfo:s0
-genfscon sysfs /devices/soc/200f000.qcom,spmi/spmi-0/spmi0-02/200f000.qcom,spmi:qcom,pmi8950@2:qcom,qpnp-smbcharger/power_supply/battery/capacity    u:object_r:sysfs_batteryinfo:s0
-
-genfscon sysfs /module/bcmdhd/parameters/firmware_path                  u:object_r:sysfs_wlan_fwpath:s0
-
+genfscon sysfs /module/bcmdhd/parameters/firmware_path                           u:object_r:sysfs_wlan_fwpath:s0
 
 genfscon sysfs /devices/platform/soc/soc:qcom,mdss_rotator                       u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/7af6000.i2c                                 u:object_r:sysfs_msm_subsys:s0


### PR DESCRIPTION
On kernel 4.9, /sys/devices/soc has been moved
to /sys/devices/platform/soc.

This branch for Android P+ and it uses kernel 4.9 only.

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>