### PR TITLE
bt: fix error in build

### DIFF
--- a/bluetooth/bdroid_buildcfg.h
+++ b/bluetooth/bdroid_buildcfg.h
@@ -43,5 +43,6 @@ static inline const char* getBTDefaultName()
 #define BTM_WBS_INCLUDED TRUE
 #define BTIF_HF_WBS_PREFERRED TRUE
 #define BLE_VND_INCLUDED TRUE
+#undef PROPERTY_VALUE_MAX
 
 #endif


### PR DESCRIPTION
without this /system/bt gives errors in build like Already defined in ./bionic/libc/include/sys/system_properties.h

Signed-off-by: David Viteri <davidteri91@gmail.com>