### PR TITLE
PlatformConfig: declare fw paths only if brcmfmac is not used

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -55,9 +55,12 @@ WPA_SUPPLICANT_VERSION      := VER_0_8_X
 BOARD_WPA_SUPPLICANT_PRIVATE_LIB := lib_driver_cmd_bcmdhd
 BOARD_HOSTAPD_DRIVER        := NL80211
 BOARD_HOSTAPD_PRIVATE_LIB   := lib_driver_cmd_bcmdhd
+# define firmware paths if not using brcmfmac driver
+ifneq ($(WIFI_DRIVER_BUILT),brcmfmac)
 WIFI_DRIVER_FW_PATH_PARAM   := "/sys/module/bcmdhd/parameters/firmware_path"
 WIFI_DRIVER_FW_PATH_AP      := "/vendor/firmware/fw_bcmdhd_apsta.bin"
 WIFI_DRIVER_FW_PATH_STA     := "/vendor/firmware/fw_bcmdhd.bin"
+endif
 
 # BT definitions for Broadcom solution
 BOARD_BLUETOOTH_BDROID_BUILDCFG_INCLUDE_DIR := $(PLATFORM_COMMON_PATH)/bluetooth


### PR DESCRIPTION
brcmfmac uses the kernel's firmware API to get what it needs.
Do not declare any fw paths in that case to avoid wifi hal failure.