### PR TITLE
Reserve 128MB for critical system components.

### DIFF
--- a/rootdir/vendor/etc/fstab.loire
+++ b/rootdir/vendor/etc/fstab.loire
@@ -5,7 +5,7 @@
 /dev/block/bootdevice/by-name/system       /system      ext4    ro,barrier=1                                                  wait,recoveryonly
 /dev/block/bootdevice/by-name/oem          /odm         ext4    ro,barrier=1                                                  wait,recoveryonly
 /dev/block/bootdevice/by-name/cache        /cache       ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic wait,check,formattable
-/dev/block/bootdevice/by-name/userdata     /data        ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic wait,check,formattable,forceencrypt=footer,quota
+/dev/block/bootdevice/by-name/userdata     /data        ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic wait,check,formattable,forceencrypt=footer,quota,reservedsize=128M
 /dev/block/bootdevice/by-name/boot         /boot        emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/FOTAKernel   /recovery    emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/config       /persistent  emmc    defaults                                                      defaults


### PR DESCRIPTION
We recently created a new GID that can be granted to critical system
processes, so that the system is usable enough for the user to free
up disk space used by abusive apps.

128MB ought to be enough for anybody.

Test: builds, boots
Bug: 62024591

Change-Id: I54bfde3fb1a198f6f6c0e03c4bf21e48324ed8fc