### PR TITLE
label 7a24900.sdhci/mmc_host/mmc2/mmc2:0001/mmc2:0001:1/net as sysfs_net

### DIFF
--- a/sepolicy_platform/genfs_contexts
+++ b/sepolicy_platform/genfs_contexts
@@ -17,6 +17,8 @@ genfscon sysfs /devices/platform/soc/soc:bcm43xx/rfkill/rfkill0/state           
 genfscon sysfs /devices/platform/soc/soc:bcmdhd_wlan/macaddr                     u:object_r:sysfs_addrsetup:s0
 genfscon sysfs /devices/platform/soc/soc:fpc1145                                 u:object_r:sysfs_fingerprint:s0
 
+genfscon sysfs /devices/platform/soc/7a24900.sdhci/mmc_host/mmc2/mmc2:0001/mmc2:0001:1/net                                     u:object_r:sysfs_net:s0
+
 genfscon sysfs /devices/platform/soc/7af6000.i2c/i2c-6/6-0042/leds                                                             u:object_r:sysfs_leds:s0
 genfscon sysfs /devices/platform/soc/200f000.qcom,spmi/spmi-0/spmi0-03/200f000.qcom,spmi:qcom,pmi8950@3:qcom,leds@d300/leds    u:object_r:sysfs_leds:s0
 genfscon sysfs /devices/platform/soc/200f000.qcom,spmi/spmi-0/spmi0-03/200f000.qcom,spmi:qcom,pmi8950@3:qcom,leds@d800/leds    u:object_r:sysfs_leds:s0


### PR DESCRIPTION
following qcom platforms and aosp sepolicy
https://android.googlesource.com/platform/system/sepolicy/+/android-9.0.0_r21/public/file.te#82
https://android.googlesource.com/platform/system/sepolicy/+/android-9.0.0_r21/private/priv_app.te#90

avoid
12-31 23:06:13.548  5269  5269 I Binder:5269_3: type=1400 audit(0.0:88): avc: denied { open } for path=/sys/devices/platform/soc/7a24900.sdhci/mmc_host/mmc2/mmc2:0001/mmc2:0001:1/net/wlan0/address dev=sysfs ino=44026 scontext=u:r:priv_app:s0:c512,c768 tcontext=u:object_r:sysfs:s0 tclass=file permissive=1
12-31 23:06:13.548  5269  5269 I Binder:5269_3: type=1400 audit(0.0:89): avc: denied { getattr } for path=/sys/devices/platform/soc/7a24900.sdhci/mmc_host/mmc2/mmc2:0001/mmc2:0001:1/net/wlan0/address dev=sysfs ino=44026 scontext=u:r:priv_app:s0:c512,c768 tcontext=u:object_r:sysfs:s0 tclass=file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>