### PR TITLE
Add default bluetooth service

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -90,6 +90,7 @@ PRODUCT_PACKAGES += \
 # BCM Bluetooth
 PRODUCT_PACKAGES += \
     android.hardware.bluetooth@1.0-impl \
+    android.hardware.bluetooth@1.0-service \
     libbt-vendor
 
 # GPS

--- a/rootdir/vendor/ueventd.rc
+++ b/rootdir/vendor/ueventd.rc
@@ -99,6 +99,9 @@
 /dev/voice_svc            0660   system     audio
 /sys/devices/virtual/smdpkt/smdcntl* open_timeout 0664 radio  radio
 
+# the DIAG device node is not world writable/readable.
+/dev/diag                 0660   system     diag
+
 # UIO devices
 /dev/uio0                 0660   system     system
 /dev/uio1                 0660   system     system


### PR DESCRIPTION
Include the default bluetooth service for loire.
Also fix permissions on /dev/diag