### PR TITLE
[loire] fstab: Mount dsp partition read-only

### DIFF
--- a/rootdir/vendor/etc/fstab.loire
+++ b/rootdir/vendor/etc/fstab.loire
@@ -9,7 +9,7 @@
 /dev/block/bootdevice/by-name/boot         /boot        emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/FOTAKernel   /recovery    emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/config       /persistent  emmc    defaults                                                      defaults
-/dev/block/bootdevice/by-name/dsp          /system/vendor/dsp              ext4    nosuid,nodev,barrier=1,data=ordered,nodelalloc,errors=panic wait,notrim
+/dev/block/bootdevice/by-name/dsp          /system/vendor/dsp              ext4    ro,nosuid,nodev,barrier=1,data=ordered,nodelalloc,errors=panic   wait,notrim
 /dev/block/bootdevice/by-name/apps_log     /misc        emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/modem        /system/vendor/firmware_mnt     vfat    ro,shortname=lower,uid=1000,gid=1000,dmask=227,fmask=337,context=u:object_r:vendor_firmware_file:s0 wait
 /dev/block/bootdevice/by-name/persist      /mnt/vendor/persist     ext4    noatime,nosuid,nodev,barrier=1,data=ordered,nodelalloc,errors=panic   wait,notrim


### PR DESCRIPTION
Since there is no longer a command in init.common.rc that remounts as read-only, set the property directly in fstab.