### PR TITLE
[HACK] rootdir: vendor: init: delay start of hwcomposer

### DIFF
--- a/rootdir/vendor/etc/init/init.loire.rc
+++ b/rootdir/vendor/etc/init/init.loire.rc
@@ -12,6 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# HACK
+# disable hwcomposer pre-emptively
+on early-boot
+    stop vendor.hwcomposer-2-1
+# start it only after surfaceflinger is running and actively waiting on hwc
+on property:init.svc.surfaceflinger=running
+    exec /system/bin/sleep 1s
+    start vendor.hwcomposer-2-1
+
 on boot
     # WLAN and BT MAC
     chown system system /sys/devices/platform/soc/soc:bcmdhd_wlan/macaddr


### PR DESCRIPTION
Loire devices will crash randomly on boot in the current setup.
After some testing, seems the issue is resolved by delaying the start of hwcomposer service.
The cause of the crash is not identified. This is just an ugly workaround till the cause is found.