### PR TITLE
[WIP] sepolicy_platform: Missing power supply paths

### DIFF
--- a/sepolicy_platform/genfs_contexts
+++ b/sepolicy_platform/genfs_contexts
@@ -28,3 +28,6 @@ genfscon sysfs /devices/platform/soc/200f000.qcom,spmi/spmi-0/spmi0-00/200f000.q
 
 genfscon sysfs /devices/platform/soc/200f000.qcom,spmi/spmi-0/spmi0-02/200f000.qcom,spmi:qcom,pmi8950@2:qcom,fg/power_supply                        u:object_r:sysfs_batteryinfo:s0
 genfscon sysfs /devices/platform/soc/200f000.qcom,spmi/spmi-0/spmi0-02/200f000.qcom,spmi:qcom,pmi8950@2:qcom,qpnp-smbcharger/power_supply           u:object_r:sysfs_batteryinfo:s0
+genfscon sysfs /devices/platform/soc/200f000.qcom,spmi/spmi-0/spmi0-02/200f000.qcom,spmi:qcom,pmi8950@2:bcl@4200/power_supply/fg_adc                u:object_r:sysfs_batteryinfo:s0
+genfscon sysfs /devices/platform/soc/7af6000.i2c/i2c-6/6-0025/power_supply/typec                                                                    u:object_r:sysfs_batteryinfo:s0
+genfscon sysfs /devices/platform/soc/200f000.qcom,spmi/spmi-0/spmi0-02/200f000.qcom,spmi:qcom,pmi8950@2:qcom,qpnp-smbcharger/power_supply/usb       u:object_r:sysfs_batteryinfo:s0


### PR DESCRIPTION
Now all the symlinks from /sys/class/power_supply/* should be labeled for loire.

android.hardwar: type=1400 audit(0.0:5): avc: denied { getattr } for \
  path="/sys/devices/platform/soc/200f000.qcom,spmi/spmi-0/spmi0-02/200f000.qcom,spmi:qcom,pmi8950@2:bcl@4200/power_supply/fg_adc/type" \
  dev="sysfs" ino=36739 scontext=u:r:hal_health_default:s0 tcontext=u:object_r:sysfs_msm_subsys:s0 tclass=file permissive=1