### PR TITLE
[WIP] PlatformConfig: Enable more FULL_TREBLE properties

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -84,4 +84,10 @@ BOARD_CACHEIMAGE_FILE_SYSTEM_TYPE := ext4
 # Platform witout a vendor partition
 TARGET_COPY_OUT_VENDOR := system/vendor
 
+# Treble
+BOARD_VNDK_VERSION := current
+PRODUCT_USE_VNDK_OVERRIDE := true
+PRODUCT_ENFORCE_VINTF_MANIFEST_OVERRIDE := true
+PRODUCT_SEPOLICY_SPLIT_OVERRIDE := true
+
 include device/sony/common/CommonConfig.mk


### PR DESCRIPTION
All loire devices should be capable of fulfilling at least some treble requirements, even though they launched with only the system partition.

- Use current VNDK
- Enforce vintf manifest, should help catch more fcm errors early
- Move and split sepolicy from root to (/system|/vendor)/etc/selinux