### PR TITLE
Change fstab mountopts

### DIFF
--- a/rootdir/vendor/etc/fstab.loire
+++ b/rootdir/vendor/etc/fstab.loire
@@ -9,7 +9,7 @@
 /dev/block/bootdevice/by-name/boot         /boot        emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/FOTAKernel   /recovery    emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/config       /persistent  emmc    defaults                                                      defaults
-/dev/block/bootdevice/by-name/dsp          /system/vendor/dsp              ext4    ro,nosuid,nodev,barrier=1,data=ordered,nodelalloc,errors=panic   wait,notrim
+/dev/block/bootdevice/by-name/dsp          /system/vendor/dsp              ext4    ro,nosuid,nodev,barrier=1,data=ordered,nodelalloc,errors=continue   wait,notrim
 /dev/block/bootdevice/by-name/apps_log     /misc        emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/modem        /system/vendor/firmware_mnt     vfat    ro,shortname=lower,uid=1000,gid=1000,dmask=227,fmask=337,context=u:object_r:vendor_firmware_file:s0 wait
 /dev/block/bootdevice/by-name/persist      /mnt/vendor/persist     ext4    noatime,nosuid,nodev,barrier=1,data=ordered,nodelalloc,errors=remount-ro   wait,notrim

--- a/rootdir/vendor/etc/fstab.loire
+++ b/rootdir/vendor/etc/fstab.loire
@@ -4,15 +4,15 @@
 
 /dev/block/bootdevice/by-name/system       /system      ext4    ro,barrier=1                                                  wait,recoveryonly
 /dev/block/bootdevice/by-name/oem          /odm         ext4    ro,barrier=1                                                  wait,recoveryonly
-/dev/block/bootdevice/by-name/cache        /cache       ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic wait,check,formattable
-/dev/block/bootdevice/by-name/userdata     /data        ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic wait,check,formattable,forceencrypt=footer,quota
+/dev/block/bootdevice/by-name/cache        /cache       ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=remount-ro wait,check,formattable
+/dev/block/bootdevice/by-name/userdata     /data        ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=remount-ro wait,check,formattable,forceencrypt=footer,quota
 /dev/block/bootdevice/by-name/boot         /boot        emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/FOTAKernel   /recovery    emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/config       /persistent  emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/dsp          /system/vendor/dsp              ext4    ro,nosuid,nodev,barrier=1,data=ordered,nodelalloc,errors=panic   wait,notrim
 /dev/block/bootdevice/by-name/apps_log     /misc        emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/modem        /system/vendor/firmware_mnt     vfat    ro,shortname=lower,uid=1000,gid=1000,dmask=227,fmask=337,context=u:object_r:vendor_firmware_file:s0 wait
-/dev/block/bootdevice/by-name/persist      /mnt/vendor/persist     ext4    noatime,nosuid,nodev,barrier=1,data=ordered,nodelalloc,errors=panic   wait,notrim
+/dev/block/bootdevice/by-name/persist      /mnt/vendor/persist     ext4    noatime,nosuid,nodev,barrier=1,data=ordered,nodelalloc,errors=remount-ro   wait,notrim
 
 /devices/platform/soc/7864900.sdhci/mmc_host/mmc*       auto    auto    nosuid,nodev                                          voldmanaged=sdcard1:auto,encryptable=userdata
 /devices/platform/soc/78db000.usb/msm_hsusb_host/usb*   auto    auto    nosuid,nodev                                          voldmanaged=usb:auto


### PR DESCRIPTION
For `userdata`, `persist` and `cache`: Use `remount-ro` instead of causing kernel panic on mount error.

For `dsp`: Do not cause kernel panic on mount error.