### PR TITLE
platform: add property to skip loading libsdmextension

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -163,6 +163,10 @@ PRODUCT_PROPERTY_OVERRIDES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     media.msm8956hw=1
 
+# Skip loading libsdmextension.so in display hal
+PRODUCT_PROPERTY_OVERRIDES += \
+    vendor.display.skip_extension_intf=1
+
 # USB controller setup
 PRODUCT_PROPERTY_OVERRIDES += \
     sys.usb.controller=msm_hsusb \


### PR DESCRIPTION
Loading the extension library fails because it can not find libscalar.so, which is indeed not provided.
This leads to failure when initializing the display hal.
Since the extension interface is not critically required on loire, skip it.