### PR TITLE
[4/4] sepolicy_platform: Label clearpad/glove sysfs attribute.

### DIFF
--- a/sepolicy_platform/genfs_contexts
+++ b/sepolicy_platform/genfs_contexts
@@ -31,3 +31,6 @@ genfscon sysfs /devices/platform/soc/200f000.qcom,spmi/spmi-0/spmi0-02/200f000.q
 genfscon sysfs /devices/platform/soc/200f000.qcom,spmi/spmi-0/spmi0-02/200f000.qcom,spmi:qcom,pmi8950@2:bcl@4200/power_supply/fg_adc                u:object_r:sysfs_batteryinfo:s0
 genfscon sysfs /devices/platform/soc/7af6000.i2c/i2c-6/6-0025/power_supply/typec                                                                    u:object_r:sysfs_batteryinfo:s0
 genfscon sysfs /devices/platform/soc/200f000.qcom,spmi/spmi-0/spmi0-02/200f000.qcom,spmi:qcom,pmi8950@2:qcom,qpnp-smbcharger/power_supply/usb       u:object_r:sysfs_batteryinfo:s0
+
+# devices/virtual/input/clearpad/glove:
+genfscon sysfs /devices/virtual/input/input3/glove u:object_r:sysfs_glove_mode:s0


### PR DESCRIPTION
For https://github.com/sonyxperiadev/packages_apps_ExtendedSettings/pull/49.

TODO: Needs to be replicated across device repos!