### PR TITLE
[master] Revert "declare TARGET_LEGACY_KEYMASTER"

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -65,9 +65,6 @@ NXP_CHIP_FW_TYPE := PN547C2
 # SELinux
 BOARD_VENDOR_SEPOLICY_DIRS += $(PLATFORM_COMMON_PATH)/sepolicy_platform
 
-# Legacy Keymaster
-TARGET_LEGACY_KEYMASTER := true
-
 # Display
 TARGET_USES_GRALLOC1 := true
 


### PR DESCRIPTION
This reverts commit 2d5a63e4cb02e8ecf26bbddd6cd7f7a1f863858d.

TARGET_LEGACY_KEYMASTER flag already defined
in PlatformConfig.mk.

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>