### PR TITLE
[master] platform: Update display property names

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -160,10 +160,9 @@ PRODUCT_PROPERTY_OVERRIDES += \
 
 ## Avoid unsupported UBWC buffers on VENC
 PRODUCT_PROPERTY_OVERRIDES += \
-    debug.gralloc.gfx_ubwc_disable=1 \
-    debug.gralloc.gfx_ubwc_disable_=1 \
-    debug.gralloc.enable_fb_ubwc=0 \
-    video.disable.ubwc=1
+    vendor.gralloc.gfx_ubwc_disable=1 \
+    vendor.gralloc.enable_fb_ubwc=0 \
+    vendor.gralloc.disable_ubwc=1
 
 # Use MSM8956 feature set for vidc encoders
 PRODUCT_PROPERTY_OVERRIDES += \


### PR DESCRIPTION
According to display HAL updates, all the properties
received prefixes vendor.display. or vendor.gralloc.,
depending on which part they belong to, so update all
properties accordingly.

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>