### PR TITLE
Revert "move msm8956 devices to kernel 4.14"

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -18,7 +18,7 @@ PLATFORM_COMMON_PATH := device/sony/loire
 TARGET_LEGACY_KEYMASTER := true
 
 SOMC_PLATFORM := loire
-SOMC_KERNEL_VERSION := 4.14
+SOMC_KERNEL_VERSION := 4.9
 KERNEL_PATH := kernel/sony/msm-$(SOMC_KERNEL_VERSION)
 
 $(call inherit-product, device/sony/common/common.mk)


### PR DESCRIPTION
This reverts commit 01cdb1528f4aaba6d9100c4a4d650e557ea11c06.

Reason for revert: 4.14 does not boot on loire at the moment.
Devices have been moved to the android-10_legacy branch and stay on Kernel 4.9.