### PR TITLE
[2/3] platform.mk: Move KERNEL_PATH to common

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -19,7 +19,6 @@ TARGET_LEGACY_KEYMASTER := true
 
 SOMC_PLATFORM := loire
 SOMC_KERNEL_VERSION := 4.9
-KERNEL_PATH := kernel/sony/msm-$(SOMC_KERNEL_VERSION)
 
 $(call inherit-product, device/sony/common/common.mk)
 $(call inherit-product, $(SRC_TARGET_DIR)/product/core_64_bit.mk)


### PR DESCRIPTION
See https://github.com/sonyxperiadev/device-sony-common/pull/669

No need to set it in platform. Simplifies the code for future reference