### PR TITLE
platform: Sync video props

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -178,6 +178,11 @@ PRODUCT_PROPERTY_OVERRIDES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     media.msm8956hw=1
 
+# SurfaceFlinger
+# Keep in sync with NUM_FRAMEBUFFER_SURFACE_BUFFERS
+PRODUCT_PROPERTY_OVERRIDES += \
+    ro.surface_flinger.max_frame_buffer_acquired_buffers=3
+
 # Skip loading libsdmextension.so in display hal
 PRODUCT_PROPERTY_OVERRIDES += \
     vendor.display.skip_extension_intf=1


### PR DESCRIPTION
The ConfigStore HAL is being deprecated and will apparently be removed in R.

See https://github.com/sonyxperiadev/device-sony-common/pull/709 for a more in-depth explanation.

Translate the uppercase makevars that `surfaceflinger.mk` used to supply as cflags to configstore internals to sysprops.

`max_frame_buffer_acquired_buffers = NUM_FRAMEBUFFER_SURFACE_BUFFER`

Note: The uppercase vars must be kept because `hardware/qcom/display` still relies on them at build time.